### PR TITLE
feat: messenger system, messenger docs, virtual docs, dependecy downl…

### DIFF
--- a/docs/api/server/document/document-virtual.md
+++ b/docs/api/server/document/document-virtual.md
@@ -1,0 +1,34 @@
+# Virtual
+
+An virtual document lets you interface with a document by `_id` and `collection`.
+
+All functions are `async` and reads data directly from the database.
+
+Virtual documents just provide a similar approach to reading / writing data while coding.
+
+## Usage
+
+```ts
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+
+type CustomDocument = { test1: string; test2: string };
+
+async function test() {
+    // Requires the _id of a document, and the collection name
+    const virtual = Rebar.document.virtual.useVirtual('663ce39eb270106cf02fb7e3', 'Characters');
+
+    // Get the document data, and set the return type
+    const someData = await virtual.get<CustomDocument>();
+    console.log(someData);
+
+    // Save data to the database
+    await virtual.set<CustomDocument>('test1', 'hi');
+    await virtual.setBulk<CustomDocument>({ test1: 'hi', test2: 'hi2' });
+
+    // Get data from the database
+    // Should be 'hi'
+    const result = await virtual.getField<CustomDocument>('test1');
+}
+```

--- a/docs/api/server/player/player-notify.md
+++ b/docs/api/server/player/player-notify.md
@@ -25,4 +25,8 @@ notify.showMissionText('Hello Mission Text!', 5000);
 // Additionally, if a notification is being intercepted on client-side. The notification will not show.
 // Thus by default it uses GTA:V built-in native notifications until it does not.
 notify.showNotification('Hello there');
+
+// Send a message to the player
+notify.sendMessage({ type: 'info', content: 'Hello there!' });
+notify.sendMessage({ type: 'player', content: 'Hello there!', author: 'Some Other Player' });
 ```

--- a/docs/api/server/systems/index.yml
+++ b/docs/api/server/systems/index.yml
@@ -1,0 +1,3 @@
+expanded: false
+label: 'Systems'
+order: -1000

--- a/docs/api/server/systems/messenger.md
+++ b/docs/api/server/systems/messenger.md
@@ -1,0 +1,49 @@
+# Messenger
+
+The messenger system allows for developers to easily send up messages from players and process them as `commands` or `messages` for other players to read.
+
+However, the messages are not automatically sent to other players. You as a developer get to decide who sees what messages or if they see text messages at all.
+
+## Usage
+
+```ts
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const messenger = Rebar.messenger.useMessenger();
+
+// Simple command, no arguments, no restrictions
+messenger.commands.register({
+    name: '/id',
+    desc: 'Print your current identifier',
+    callback: (player: alt.Player) => {
+        messenger.message.send(player, { type: 'info', content: `ID: ${player.id}` });
+    },
+});
+
+// Gated command, requires permissions
+// Below checks if a 'account' has the 'moderator' permission before executing the command
+messenger.commands.register({
+    name: '/goto',
+    desc: '/goto [x][y][z]',
+    options: { accountPermissions: ['moderator'] },
+    callback: (player: alt.Player, x: string, y: string, z: string) => {
+        try {
+            const pos = new alt.Vector3(parseFloat(x), parseFloat(y), parseFloat(z));
+            player.pos = pos;
+        } catch (err) {
+            messenger.message.send(player, { type: 'warning', content: 'X,Y,Z coords were not valid.' });
+        }
+    },
+});
+
+messenger.message.on((player: alt.Player, msg: string) => {
+    // You shouldn't use `player.name` in production.
+    console.log(`${player.name} says: ${msg}`);
+
+    // Let's forward the message to all players!
+    for (let player of alt.Player.all) {
+        messenger.message.send(player, { type: 'player', content: msg, author: player.name });
+    }
+});
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,25 @@
+---
+order: -1000
+---
+
+# Changelog
+
+## Version 1
+
+### Code Changes
+
+-   Added `package.json` or `dependency.json` support to plugins
+-   Added an install pipeline for plugins that need specific npm packages
+-   Added ability to disable a plugin by creating a file called `.disable` in the given plugin folder
+-   Added `useMessenger` to server-side for processing user commands, and chat system (not console commands)
+-   useMessenger also provides onMessage, sending messages, registering commands, and invoking commands
+-   Added `useMessenger` composable to `webview` for `emitting` messages to the server for processing, automatically handles commands
+    -   Additional note, messages are sent to the void and go nowhere until a chat plugin is added
+    -   This is effectively a messenger middleware for building a chat or command system
+-   Added `sendMessage` to the `useNotify` player composable
+
+### Docs Changes
+
+-   Added question about NPM packages to FAQ docs
+-   Updated what is a plugin, and create docs to clarify new changes
+-   Updated `useNotify` docs for `sendMessage`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,5 +21,7 @@ order: -1000
 ### Docs Changes
 
 -   Added question about NPM packages to FAQ docs
+-   Added `virtual` document type docs to the `API/Document` section
 -   Updated what is a plugin, and create docs to clarify new changes
 -   Updated `useNotify` docs for `sendMessage`
+-   Added `useMessenger` docs for composable, and server-side

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,6 +32,10 @@ To run your own database you will need to write it as a plugin and use it exclus
 
 Doing so may limit your ability to load plugins from other users.
 
+## Can I use npm packages client-side
+
+Nope! You won't ever be able to. However, you can use them in the webview, and on server-side.
+
 ## Do I need to buy a server?
 
 Only buy a server when you're ready for your server to go live.

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,7 +27,7 @@ set-executionpolicy unrestricted
 ## Setup
 
 !!!
-Never run the `altv-server` binary directly, you must use `pnpm` commands
+Never run the `altv-server` binary directly, you should use `pnpm` commands
 !!!
 
 ---

--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -10,6 +10,7 @@ If you wish to create plugins then you need to understand the basic structure of
     4. `sounds`
     5. `translate`
     6. `webview`
+    7. `dependencies`
 
 ## client
 
@@ -190,4 +191,24 @@ const boundVehicle = Rebar.document.vehicle.useVehicleBinder(vehicle).bind(vehic
 
 vehicleWrapper.getField('mileage'); // You will see type hint there, that you're able to use 'mileage' and 'plateNumber'.
 vehicleWrapper.set('mileage', 1000); // Also here
+```
+
+## Dependencies
+
+If you noticed a plugin can use npm packages for the webview or server.
+
+!!!
+It is recommended to avoid using packages where possible to keep everything 'future proofed'
+!!!
+
+Simply add a `dependencies.json` or `package.json` to your plugin folder.
+
+Add a section called `dependencies` and it will automatically install the dependencies the next time you run your server.
+
+```json
+{
+    "dependencies": {
+        "@formkit/auto-animate": "latest"
+    }
+}
 ```

--- a/docs/plugins/what-is-a-plugin.md
+++ b/docs/plugins/what-is-a-plugin.md
@@ -20,6 +20,7 @@ Plugins can be found in the `src/plugins` directory, and each plugin should have
 │   └───translate
 └───plugins
     └───your-plugin
+        ├───dependencies.json (alt: package.json)
         ├───client
         │   └───index.ts
         ├───images
@@ -42,14 +43,24 @@ See [create a plugin](./create.md) for more information.
 
 If you wish to disable a plugin simply add a `!` before the folder name.
 
-### Before
+Alternatively you can add a file named `.disable` to the plugin folder to disable it.
 
-```
-src/plugins/myplugin
-```
+## Adding Dependencies
 
-### After
+If you noticed a plugin can use npm packages for the webview or server.
 
-```
-src/plugins/!myplugin
+!!!
+It is recommended to avoid using packages where possible to keep everything 'future proofed'
+!!!
+
+Simply add a `dependencies.json` or `package.json` to your plugin folder.
+
+Add a section called `dependencies` and it will automatically install the dependencies the next time you run your server.
+
+```json
+{
+    "dependencies": {
+        "@formkit/auto-animate": "latest"
+    }
+}
 ```

--- a/docs/webview/composables/use-messenger.md
+++ b/docs/webview/composables/use-messenger.md
@@ -1,0 +1,20 @@
+# useMessenger
+
+Gives the ability to get `messages` from the messenger system as well as `emit messages` to the messenger system.
+
+```html
+<script lang="ts" setup>
+    import { useMessenger } from '../../../../webview/composables/useMessenger';
+
+    const messenger = useMessenger();
+
+    // Issue a command
+    messenger.emit(`/id`);
+
+    // Issue a message
+    messenger.emit(`hi there!`);
+
+    // Log all current messages, this is a ref variable for vue
+    console.log(messenger.messages);
+</script>
+```

--- a/scripts/buildPluginDependencies.js
+++ b/scripts/buildPluginDependencies.js
@@ -1,0 +1,50 @@
+import * as fs from 'fs';
+import glob from 'fast-glob';
+import { execSync } from 'child_process';
+
+async function buildDependencies() {
+    const filePaths = [
+        ...glob.sync('./src/plugins/**/package.json'),
+        ...glob.sync('./src/plugins/**/dependencies.json'),
+    ];
+
+    if (filePaths.length <= 0) {
+        return;
+    }
+
+    const packageList = [];
+    for (let filePath of filePaths) {
+        const file = fs.readFileSync(filePath);
+
+        try {
+            /** @type {{ dependencies?: { [key: string]: string }}} */
+            const data = JSON.parse(file);
+            if (!data.dependencies) {
+                continue;
+            }
+
+            for (let packageName of Object.keys(data.dependencies)) {
+                if (fs.existsSync(`node_modules/${packageName}`)) {
+                    continue;
+                }
+
+                packageList.push(`${packageName}@${data.dependencies[packageName]}`);
+            }
+        } catch (err) {
+            console.warn(`Could not read, is JSON file valid? ${filePath}`);
+        }
+    }
+
+    if (packageList.length <= 0) {
+        return;
+    }
+
+    const cmd = `pnpm install ${packageList.join(' ')}`;
+    try {
+        execSync(cmd, { stdio: 'inherit' });
+    } catch (err) {
+        console.warn(`Failed to install additional dependencies.`);
+    }
+}
+
+buildDependencies();

--- a/scripts/buildPluginImports.js
+++ b/scripts/buildPluginImports.js
@@ -21,7 +21,7 @@ async function start() {
 
     // Propogate server import paths
     for (let serverFolder of serverFolders) {
-        if (serverFolder.includes('!')) {
+        if (serverFolder.includes('!') || fs.existsSync(serverFolder + '/.disable')) {
             continue;
         }
 

--- a/src/main/server/index.ts
+++ b/src/main/server/index.ts
@@ -39,6 +39,7 @@ import { usePermissionGroup } from './systems/permissionGroup.js';
 import { sha256, sha256Random } from './utility/hash.js';
 import { check, hash } from './utility/password.js';
 import { usePickupGlobal } from './controllers/pickups.js';
+import { useMessenger } from './systems/messenger.js';
 
 export function useRebar() {
     return {
@@ -99,6 +100,9 @@ export function useRebar() {
             useNotify,
             useWebview,
             useWorld,
+        },
+        messenger: {
+            useMessenger,
         },
         permission: {
             usePermission,

--- a/src/main/server/player/notify.ts
+++ b/src/main/server/player/notify.ts
@@ -3,6 +3,10 @@ import { Events } from '@Shared/events/index.js';
 import { Spinner } from '@Shared/types/spinner.js';
 import { Shard } from '@Shared/types/shard.js';
 import { Credit } from '@Shared/types/credits.js';
+import { Message } from '@Shared/types/message.js';
+import { useMessenger } from '../systems/messenger.js';
+
+const messenger = useMessenger();
 
 export function useNotify(player: alt.Player) {
     function showNotification(message: string) {
@@ -45,7 +49,12 @@ export function useNotify(player: alt.Player) {
         player.emit(Events.player.notify.credits.create, credits);
     }
 
+    function sendMessage(message: Message) {
+        messenger.message.send(player, message);
+    }
+
     return {
+        sendMessage,
         showNotification,
         showMissionText,
         showSpinner,

--- a/src/main/server/systems/messenger.ts
+++ b/src/main/server/systems/messenger.ts
@@ -1,0 +1,145 @@
+import * as alt from 'alt-server';
+import { useRebar } from '../index.js';
+import { Events } from '../../shared/events/index.js';
+import { Message } from '../../shared/types/message.js';
+
+export type PlayerMessageCallback = (player: alt.Player, msg: string) => void;
+
+export type CommandOptions = {
+    permissions?: string[];
+    accountPermissions?: string[];
+};
+
+export type Command = {
+    name: string;
+    desc: string;
+    options?: CommandOptions;
+    callback: (player: alt.Player, ...args: any[]) => void | boolean;
+};
+
+const tagOrComment = new RegExp(
+    '<(?:' +
+        // Comment body.
+        '!--(?:(?:-*[^->])*--+|-?)' +
+        // Special "raw text" elements whose content should be elided.
+        '|script\\b' +
+        '(?:[^"\'>]|"[^"]*"|\'[^\']*\')*' +
+        '>[\\s\\S]*?</script\\s*' +
+        '|style\\b' +
+        '(?:[^"\'>]|"[^"]*"|\'[^\']*\')*' +
+        '>[\\s\\S]*?</style\\s*' +
+        // Regular name
+        '|/?[a-z]' +
+        '(?:[^"\'>]|"[^"]*"|\'[^\']*\')*' +
+        ')>',
+    'gi',
+);
+
+const Rebar = useRebar();
+
+const commands: Command[] = [];
+const callbacks: PlayerMessageCallback[] = [];
+
+export function useMessenger() {
+    function registerCommand(command: Command) {
+        const index = commands.findIndex((x) => x.name === command.name);
+        if (index >= 1) {
+            throw new Error(`${command.name} is already a registered command.`);
+        }
+
+        command.name = command.name.replaceAll('/', '');
+        commands.push(command);
+    }
+
+    function onMessage(cb: PlayerMessageCallback) {
+        callbacks.push(cb);
+    }
+
+    function invokeCommand(player: alt.Player, cmdName: string, ...args: any[]): boolean {
+        const index = commands.findIndex((x) => x.name === cmdName);
+        if (index <= -1) {
+            return false;
+        }
+
+        const command = commands[index];
+        if (command.options) {
+            const permissions = Rebar.permission.usePermission(player);
+
+            let allValid = true;
+            if (command.options.accountPermissions) {
+                allValid = permissions.hasOne('account', command.options.accountPermissions);
+            }
+
+            if (command.options.permissions) {
+                allValid = permissions.hasOne('character', command.options.permissions);
+            }
+
+            if (!allValid) {
+                return false;
+            }
+        }
+
+        try {
+            command.callback(player, ...args);
+            return true;
+        } catch (err) {
+            return false;
+        }
+    }
+
+    function sendMessage(player: alt.Player, message: Message) {
+        const webview = Rebar.player.useWebview(player);
+        webview.emit(Events.systems.messenger.send, message);
+    }
+
+    return {
+        commands: {
+            invoke: invokeCommand,
+            register: registerCommand,
+        },
+        message: {
+            on: onMessage,
+            send: sendMessage,
+        },
+    };
+}
+
+/**
+ * Removes HTML brackets, and other escaped garbage.
+ *
+ * @param {string} msg
+ * @return {string}
+ */
+function cleanMessage(msg: string): string {
+    return msg
+        .replace(tagOrComment, '')
+        .replace('/</g', '&lt;')
+        .replace('/', '')
+        .replace(/<\/?[^>]+(>|$)/gm, '');
+}
+
+/**
+ * Process a command sent up from the client
+ *
+ * @param {alt.Player} player
+ * @param {string} msg
+ * @return
+ */
+function processMessage(player: alt.Player, msg: string) {
+    const messageSystem = useMessenger();
+    msg = cleanMessage(msg);
+
+    if (msg.charAt(0) !== '/') {
+        for (let cb of callbacks) {
+            cb(player, msg);
+        }
+
+        return;
+    }
+
+    const args = msg.split(' ');
+    const commandName = args.shift();
+    messageSystem.commands.invoke(player, commandName.toLowerCase(), args);
+}
+
+alt.onClient(Events.systems.messenger.process, processMessage);

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -82,6 +82,12 @@ export const Events = {
             },
         },
     },
+    systems: {
+        messenger: {
+            process: 'systems:messenger:process',
+            send: 'systems:messenger:send',
+        },
+    },
     view: {
         onServer: 'webview:on:server',
         onEmit: 'webview:emit:on',

--- a/src/main/shared/types/message.ts
+++ b/src/main/shared/types/message.ts
@@ -1,0 +1,6 @@
+export type Message = {
+    type: 'player' | 'system' | 'alert' | 'warning' | 'info';
+    author?: string;
+    content: string;
+    timestamp?: number;
+};

--- a/webview/composables/useMessenger.ts
+++ b/webview/composables/useMessenger.ts
@@ -1,0 +1,51 @@
+import { ref } from 'vue';
+import { useEvents } from './useEvents.js';
+import { Events } from '../../src/main/shared/events/index.js';
+import { Message } from '../../src/main/shared/types/message.js';
+
+const MAXIMUM_MESSAGES = 256;
+const messages = ref<Message[]>([{ type: 'info', content: 'Rebar Started', timestamp: Date.now() }]);
+const events = useEvents();
+let isInit = false;
+
+function processMessage(message: Message) {
+    if (!message.timestamp) {
+        message.timestamp = Date.now();
+    }
+
+    messages.value.unshift(message);
+
+    if (messages.value.length >= MAXIMUM_MESSAGES) {
+        messages.value.pop();
+    }
+
+    console.log(JSON.stringify(message));
+}
+
+export function useMessenger() {
+    if (!isInit) {
+        isInit = true;
+        events.on(Events.systems.messenger.send, processMessage);
+    }
+
+    /**
+     * Allows you to directly emit a user message to the server to be handled by the message system.
+     *
+     * This function is used for making chat systems.
+     *
+     * @param {string} msg
+     */
+    function emit(msg: string) {
+        if (!('alt' in window)) {
+            console.log(`[Webview] Mock Event Message: ${msg}`);
+            return;
+        }
+
+        alt.emit(Events.view.emitServer, Events.systems.messenger.process, msg);
+    }
+
+    return {
+        emit,
+        messages,
+    };
+}

--- a/webview/src/App.vue
+++ b/webview/src/App.vue
@@ -4,6 +4,7 @@ import { usePages } from '../composables/usePages';
 import { usePageEvents } from '../composables/usePageEvents';
 import { useAudio } from '../composables/useAudio';
 import DevelopmentBar from './components/Development.vue';
+import { useMessenger } from '../composables/useMessenger';
 
 const { pagesPersistent, pagesOverlay, page } = usePages();
 const { init } = usePageEvents();
@@ -16,6 +17,7 @@ function handleMount() {
 
     init();
     useAudio();
+    useMessenger();
 }
 
 onMounted(handleMount);
@@ -23,7 +25,7 @@ onMounted(handleMount);
 
 <template>
     <div
-        class="flex relative top-0 left-0 w-full h-full min-h-full min-w-full overflow-hidden"
+        class="relative left-0 top-0 flex h-full min-h-full w-full min-w-full overflow-hidden"
         :class="isDeveloping ? ['devbg'] : []"
     >
         <DevelopmentBar v-if="isDeveloping" />


### PR DESCRIPTION
## Version 1

### Code Changes

-   Added `package.json` or `dependency.json` support to plugins
-   Added an install pipeline for plugins that need specific npm packages
-   Added ability to disable a plugin by creating a file called `.disable` in the given plugin folder
-   Added `useMessenger` to server-side for processing user commands, and chat system (not console commands)
-   useMessenger also provides onMessage, sending messages, registering commands, and invoking commands
-   Added `useMessenger` composable to `webview` for `emitting` messages to the server for processing, automatically handles commands
    -   Additional note, messages are sent to the void and go nowhere until a chat plugin is added
    -   This is effectively a messenger middleware for building a chat or command system
-   Added `sendMessage` to the `useNotify` player composable

### Docs Changes

-   Added question about NPM packages to FAQ docs
-   Added `virtual` document type docs to the `API/Document` section
-   Updated what is a plugin, and create docs to clarify new changes
-   Updated `useNotify` docs for `sendMessage`
-   Added `useMessenger` docs for composable, and server-side