### PR TITLE
feat: time events

### DIFF
--- a/docs/api/server/events/events.md
+++ b/docs/api/server/events/events.md
@@ -29,4 +29,24 @@ RebarEvents.on('vehicle-bound', (vehicle, document) => {
 RebarEvents.on('message', (player, msg) => {
     console.log(msg);
 });
+
+// Called whenever the time changes
+RebarEvents.on('time-changed', (hour, minute, second) => {
+    console.log(hour, minute, second);
+});
+
+// Called whenever the hour increments by 1
+RebarEvents.on('time-hour-changed', (hour) => {
+    console.log(hour);
+});
+
+// Called whenever the minute increments by 1
+RebarEvents.on('time-minute-changed', (minute) => {
+    console.log(minute);
+});
+
+// Called whenever the second increments by 1
+RebarEvents.on('time-second-changed', (second) => {
+    console.log(second);
+});
 ```

--- a/docs/api/server/systems/useServerTime.md
+++ b/docs/api/server/systems/useServerTime.md
@@ -1,0 +1,24 @@
+# useServerTime
+
+This stores server time during runtime, and allows for time to be shared to other plugins.
+
+Additionally, when these functions are used the internal RebarEvents for time changes are invoked.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const ServerTime = Rebar.useServerTime();
+
+function whatever() {
+    // Returns { hour, minute, second }
+    const { hour, minute, second } = ServerTime.getTime();
+
+    // Get current time
+    const currentTime = new Date(Date.now());
+    ServerTime.setHour(currentTime.getHours());
+    ServerTime.setMinute(currentTime.getMinutes());
+    ServerTime.setSecond(currentTime.getSeconds());
+}
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,20 @@ order: -5
 
 # Changelog
 
+## Version 10
+
+### Code Changes
+
+-   Added `ignore` and `autogen` as a keyword to ignore file changes when developing
+-   Added `time-changed`, `time-second-changed`, `time-minute-changed`, and `time-hour-changed` events to core events
+-   Added `useServerTime` setters / getters for managing server time more effectively
+    -   Note: This does not auto-sync on players, other plugins can build more complex time systems
+
+### Docs Changes
+
+-   Added `useServerTime` API docs
+-   Added `time-changed`, `time-second-changed`, `time-minute-changed`, and `time-hour-changed` event documentation
+
 ## Version 9
 
 ### Code Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "author": "stuyk",
     "type": "module",
-    "version": "9",
+    "version": "10",
     "scripts": {
         "clean": "shx rm -rf resources/core",
         "dev": "nodemon -x pnpm start",
@@ -76,7 +76,8 @@
             "webview/vite.config.*",
             "*/package.json",
             "*.mjs",
-            "ignore*.ts"
+            "ignore*.ts",
+            "autogen*.ts"
         ]
     }
 }

--- a/src/main/server/database/index.ts
+++ b/src/main/server/database/index.ts
@@ -125,7 +125,7 @@ export function useDatabase() {
      */
     async function get<T extends { [key: string]: any; _id?: string | ObjectId }>(
         dataToMatch: Partial<T>,
-        collection: string
+        collection: string,
     ): Promise<T | undefined> {
         const client = await getClient();
 
@@ -159,7 +159,7 @@ export function useDatabase() {
      */
     async function getMany<T extends { [key: string]: any }>(
         dataToMatch: Partial<T>,
-        collection: string
+        collection: string,
     ): Promise<T[]> {
         const client = await getClient();
 
@@ -190,9 +190,7 @@ export function useDatabase() {
      * @param {string} collection
      * @return {(Promise<(T & { _id: string })[] | undefined>)}
      */
-    async function getAll<T extends { _id: ObjectId }>(
-        collection: string
-    ): Promise<(T & { _id: string })[] | undefined> {
+    async function getAll<T extends { _id: string }>(collection: string): Promise<(T & { _id: string })[] | undefined> {
         const client = await getClient();
 
         try {

--- a/src/main/server/events/index.ts
+++ b/src/main/server/events/index.ts
@@ -4,6 +4,10 @@ import { Character } from '@Shared/types/character.js';
 import { Vehicle } from '@Shared/types/vehicle.js';
 
 type RebarEvents = {
+    'time-changed': (hour: number, minute: number, second: number) => void;
+    'time-second-changed': (minute: number) => void;
+    'time-minute-changed': (minute: number) => void;
+    'time-hour-changed': (hour: number) => void;
     'account-bound': (player: alt.Player, document: Account) => void;
     'character-bound': (player: alt.Player, document: Character) => void;
     'vehicle-bound': (vehicle: alt.Vehicle, document: Vehicle) => void;
@@ -13,6 +17,10 @@ type RebarEvents = {
 type EventCallbacks<K extends keyof RebarEvents> = { [key in K]: RebarEvents[K][] };
 
 const eventCallbacks: EventCallbacks<keyof RebarEvents> = {
+    'time-changed': [],
+    'time-second-changed': [],
+    'time-hour-changed': [],
+    'time-minute-changed': [],
     'account-bound': [],
     'character-bound': [],
     'vehicle-bound': [],

--- a/src/main/server/index.ts
+++ b/src/main/server/index.ts
@@ -57,6 +57,7 @@ import { sha256, sha256Random } from './utility/hash.js';
 import { check, hash } from './utility/password.js';
 import { useVehicle } from './vehicle/index.js';
 import { useProtectCallback } from './utility/protectCallback.js';
+import { useServerTime } from './systems/serverTime.js';
 
 export function useRebar() {
     return {
@@ -133,6 +134,7 @@ export function useRebar() {
             usePermissionGroup,
         },
         usePlayer,
+        useServerTime,
         utility: {
             sha256,
             sha256Random,

--- a/src/main/server/systems/serverTime.ts
+++ b/src/main/server/systems/serverTime.ts
@@ -1,0 +1,88 @@
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const RebarEvents = Rebar.events.useEvents();
+
+const time = {
+    hour: 8,
+    minute: 0,
+    second: 0,
+};
+
+/**
+ * Server time is the in-world time for the server and not real world time.
+ *
+ * @export
+ * @return
+ */
+export function useServerTime() {
+    /**
+     * Set the in-game world time
+     *
+     * @param {number} value
+     */
+    function setHour(value: number) {
+        if (value >= 24) {
+            value = 0;
+        }
+
+        if (time.hour !== value) {
+            RebarEvents.invoke('time-hour-changed', value);
+            RebarEvents.invoke('time-changed', time.hour, time.minute, time.second);
+        }
+
+        time.hour = value;
+    }
+
+    /**
+     * Set the in-game world minute
+     *
+     * @param {number} value
+     */
+    function setMinute(value: number) {
+        if (value >= 60) {
+            value = 0;
+        }
+
+        if (time.minute !== value) {
+            RebarEvents.invoke('time-minute-changed', value);
+            RebarEvents.invoke('time-changed', time.hour, time.minute, time.second);
+        }
+
+        time.minute = value;
+    }
+
+    /**
+     * Set the in-game world second
+     *
+     * @param {number} value
+     */
+    function setSecond(value: number) {
+        if (value >= 60) {
+            value = 0;
+        }
+
+        if (time.minute !== value) {
+            RebarEvents.invoke('time-second-changed', value);
+            RebarEvents.invoke('time-changed', time.hour, time.minute, time.second);
+        }
+
+        time.second = value;
+    }
+
+    /**
+     * Get the current in-game world time
+     *
+     * @return
+     */
+    function getTime() {
+        return time;
+    }
+
+    return {
+        getTime,
+        setHour,
+        setMinute,
+        setSecond,
+    };
+}


### PR DESCRIPTION
## Version 10

### Code Changes

-   Added `ignore` and `autogen` as a keyword to ignore file changes when developing
-   Added `time-changed`, `time-second-changed`, `time-minute-changed`, and `time-hour-changed` events to core events
-   Added `useServerTime` setters / getters for managing server time more effectively
    -   Note: This does not auto-sync on players, other plugins can build more complex time systems

### Docs Changes

-   Added `useServerTime` API docs
-   Added `time-changed`, `time-second-changed`, `time-minute-changed`, and `time-hour-changed` event documentation
