### PR TITLE
14

### DIFF
--- a/docs/api/client/webview/webview.md
+++ b/docs/api/client/webview/webview.md
@@ -45,4 +45,9 @@ useWebview().showCursor(true);
 
 // Hide cursor
 useWebview().showCursor(false);
+
+// Handles RPC calls from the webview on the client-side
+useWebview().onRpc('some-event', () => {
+    return 'hello there'
+});
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,20 @@ order: -5
 
 # Changelog
 
+## Version 14
+
+### Code Changes
+
+- Added `emitServerRpc` to Webview to retrieve data from server-side using normal `alt.onRpc` events.
+  - Yes, this means you don't have to do weird event bindings to get data now.
+- Added `emitClientRpc` to Webview to retrieve data from client-side.
+
+### Docs Changes
+
+- Added `emitServerRpc` and `emitClientRpc` to docs
+
+---
+
 ## Version 13
 
 ### Code Changes

--- a/docs/webview/composables/use-events.md
+++ b/docs/webview/composables/use-events.md
@@ -19,5 +19,41 @@ This is an event wrapper that allows for communication directly to the server, o
 
     // Can be recieved with the alt.onClient event
     events.emitServer('emit-to-server-event', myVariable);
+
+    // Emit to the server-side RPC and get a result from the server
+    const result = await events.emitServerRpc('get-something', 'hello');
+    console.log(`Webview Result: ${result}`);
+
+    // Emit to the client-side, but only works with useWebview().onRpc('get-something', () => {})
+    const result = await events.emitClientRpc('get-something', 'hello');
 </script>
+```
+
+## Server Side RPC Handling
+
+If you use the event `emitServerRpc` you can use the normal `alt.onRpc` to handle the request.
+
+A simple but seamless integration with existing alt:V APIs.
+
+```ts
+import * as alt from 'alt-server';
+
+alt.onRpc('get-something', (player, arg1: string) => {
+    const result = arg1 + ' world';
+    return result;
+});
+```
+
+## Client Side RPC Handling
+
+This one works differently on client-side, so you'll have to access the `useWebview` function, and then add your listener callback.
+
+```ts
+import { useWebview } from '@Client/webview/index.js';
+
+const view = useWebview();
+
+view.onRpc('get-something', (arg1: string) => {
+    return arg1 + ' world';
+});
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "author": "stuyk",
     "type": "module",
-    "version": "13",
+    "version": "14",
     "scripts": {
         "dev": "nodemon -x pnpm start",
         "dev:linux": "nodemon -x pnpm start:linux",

--- a/src/main/server/utility/version.ts
+++ b/src/main/server/utility/version.ts
@@ -18,14 +18,16 @@ async function init() {
     }
 
     const data: { version: number } = await req.json();
-    if (data.version != packageContent.version) {
-        alt.setTimeout(() => {
-            alt.logWarning(
-                `Version ${data.version} of Rebar is now available! You are on version ${packageContent.version}.`,
-            );
-            alt.logWarning(`Check https://rebarv.com/upgrade for instructions.`);
-        }, 3000);
+    if (data.version == packageContent.version || packageContent.version > data.version) {
+       return;
     }
+
+    alt.setTimeout(() => {
+        alt.logWarning(
+            `Version ${data.version} of Rebar is now available! You are on version ${packageContent.version}.`,
+        );
+        alt.logWarning(`Check https://rebarv.com/upgrade for instructions.`);
+    }, 3000);
 }
 
 init();

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -95,6 +95,8 @@ export const Events = {
         onServer: 'webview:on:server',
         onEmit: 'webview:emit:on',
         onKeypress: 'webview:emit:keypress',
+        emitClientRpc: 'webview:emit:client:rpc',
+        emitServerRpc: 'webview:emit:server:rpc',
         emitServer: 'webview:emit:server',
         emitClient: 'webview:emit:client',
         emitReady: 'webview:emit:page:ready',

--- a/webview/composables/useLocalStorage.ts
+++ b/webview/composables/useLocalStorage.ts
@@ -2,6 +2,8 @@ import { Events } from '../../src/main/shared/events/index.js';
 
 const requests: { [key: string]: Function } = {};
 
+let isInit = false;
+
 function handleLocalStorage(key: string, value: any) {
     if (!requests[key]) {
         return;
@@ -12,6 +14,13 @@ function handleLocalStorage(key: string, value: any) {
 }
 
 export function useLocalStorage() {
+    if (!isInit) {
+        isInit = true;
+        if ('alt' in window) {
+            alt.on(Events.view.localStorageGet, handleLocalStorage)
+        }
+    }
+
     function set(key: string, value: any) {
         if (!('alt' in window)) {
             return;
@@ -50,8 +59,4 @@ export function useLocalStorage() {
         remove,
         set,
     }
-}
-
-if ('alt' in window) {
-    alt.on(Events.view.localStorageGet, handleLocalStorage)
 }


### PR DESCRIPTION
## Version 14

### Code Changes

- Added `emitServerRpc` to Webview to retrieve data from server-side using normal `alt.onRpc` events.
  - Yes, this means you don't have to do weird event bindings to get data now.
- Added `emitClientRpc` to Webview to retrieve data from client-side.

### Docs Changes

- Added `emitServerRpc` and `emitClientRpc` to docs****