### PR TITLE
feat: character interface fix, alt.meta based api usage, doc updates

### DIFF
--- a/docs/api/client/client-api-usage.md
+++ b/docs/api/client/client-api-usage.md
@@ -1,19 +1,19 @@
-# Server API Usage
+# Client API Usage
 
-The server API can be accessed through a single import.
+The client API can be accessed through a single import.
 
 If you want more direct imports, those are also available through your intellisense.
 
 ## alt:V Based Import
 ```ts
-import * as alt from 'alt-server';
+import * as alt from 'alt-client';
 
-const Rebar = alt.getMeta('Rebar');
+const Rebar = alt.getMeta('RebarClient');
 ```
 
 ## Direct Import
 ```ts
-import { useRebar } from '@Server/index.js';
+import { useRebar } from '@Client/index.js';
 
 const Rebar = useRebar();
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,21 @@ order: -5
 
 # Changelog
 
+## Version 17
+
+### Code Changes
+
+- Added `alt.getMeta('Rebar')` to get Server API with one-less import
+- Added `alt.getMeta('RebarClient')` to get Client API with one-less import
+- Fixed character interface not being extended correctly
+- Added `preinstall` script to download binaries, and build codebase once
+  
+### Docs Changes
+
+- Covered alternative API import methods in docs
+
+---
+
 ## Version 16
 
 ### Code Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "author": "stuyk",
     "type": "module",
-    "version": "16",
+    "version": "17",
     "scripts": {
         "dev": "nodemon -x pnpm start",
         "dev:linux": "nodemon -x pnpm start:linux",
@@ -10,7 +10,8 @@
         "build:docker": "node ./scripts/compile.js -- docker",
         "binaries": "pnpm altv-pkg",
         "rebar:upgrade": "node ./scripts/upgrade.js",
-        "webview:dev": "node ./scripts/buildPluginDependencies.js && node ./scripts/copyFiles.js && node ./scripts/webview.js && pnpm -C webview run dev"
+        "webview:dev": "node ./scripts/buildPluginDependencies.js && node ./scripts/copyFiles.js && node ./scripts/webview.js && pnpm -C webview run dev",
+        "preinstall": "pnpm binaries && pnpm build:docker"
     },
     "devDependencies": {
         "@altv/types-client": "^16.2.2",
@@ -19,19 +20,19 @@
         "@altv/types-shared": "^16.2.1",
         "@altv/types-webview": "^16.2.1",
         "@altv/types-worker": "^16.2.0",
-        "@types/node": "^20.14.1",
+        "@types/node": "^20.14.2",
         "altv-pkg": "^2.7.5",
         "autoprefixer": "^10.4.19",
         "fast-glob": "^3.3.2",
         "fkill": "^9.0.0",
         "nodemon": "^3.1.3",
         "postcss": "^8.4.38",
-        "prettier": "^3.3.0",
+        "prettier": "^3.3.1",
         "prettier-plugin-tailwindcss": "^0.5.14",
         "retypeapp": "^3.5.0",
         "shx": "^0.3.4",
         "sucrase": "^3.35.0",
-        "tailwindcss": "^3.4.3"
+        "tailwindcss": "^3.4.4"
     },
     "dependencies": {
         "@vitejs/plugin-vue": "^5.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ dependencies:
     version: 5.4.5
   vite:
     specifier: ^5.2.12
-    version: 5.2.12(@types/node@20.14.1)
+    version: 5.2.12(@types/node@20.14.2)
   vue:
     specifier: ^3.4.27
     version: 3.4.27(typescript@5.4.5)
@@ -50,8 +50,8 @@ devDependencies:
     specifier: ^16.2.0
     version: 16.2.0(@altv/types-client@16.2.2)
   '@types/node':
-    specifier: ^20.14.1
-    version: 20.14.1
+    specifier: ^20.14.2
+    version: 20.14.2
   altv-pkg:
     specifier: ^2.7.5
     version: 2.7.5
@@ -71,11 +71,11 @@ devDependencies:
     specifier: ^8.4.38
     version: 8.4.38
   prettier:
-    specifier: ^3.3.0
-    version: 3.3.0
+    specifier: ^3.3.1
+    version: 3.3.1
   prettier-plugin-tailwindcss:
     specifier: ^0.5.14
-    version: 0.5.14(prettier@3.3.0)
+    version: 0.5.14(prettier@3.3.1)
   retypeapp:
     specifier: ^3.5.0
     version: 3.5.0
@@ -86,8 +86,8 @@ devDependencies:
     specifier: ^3.35.0
     version: 3.35.0
   tailwindcss:
-    specifier: ^3.4.3
-    version: 3.4.3
+    specifier: ^3.4.4
+    version: 3.4.4
 
 packages:
 
@@ -138,30 +138,30 @@ packages:
       '@altv/types-client': 16.2.2(@altv/types-shared@16.2.1)(@altv/types-worker@16.2.0)
     dev: true
 
-  /@babel/helper-string-parser@7.24.6:
-    resolution: {integrity: sha512-WdJjwMEkmBicq5T9fm/cHND3+UlFa2Yj8ALLgmoSQAJZysYbBjw+azChSGPN4DSPLXOcooGRvDwZWMcF/mLO2Q==}
+  /@babel/helper-string-parser@7.24.7:
+    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/helper-validator-identifier@7.24.6:
-    resolution: {integrity: sha512-4yA7s865JHaqUdRbnaxarZREuPTHrjpDT+pXoAZ1yhyo6uFnIEpS8VMu16siFOHDpZNKYv5BObhsB//ycbICyw==}
+  /@babel/helper-validator-identifier@7.24.7:
+    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@babel/parser@7.24.6:
-    resolution: {integrity: sha512-eNZXdfU35nJC2h24RznROuOpO94h6x8sg9ju0tT9biNtLZ2vuP8SduLqqV+/8+cebSLV9SJEAN5Z3zQbJG/M+Q==}
+  /@babel/parser@7.24.7:
+    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.24.6
+      '@babel/types': 7.24.7
     dev: false
 
-  /@babel/types@7.24.6:
-    resolution: {integrity: sha512-WaMsgi6Q8zMgMth93GvWPXkhAIEobfsIkLTacoVZoK1J0CevIPGYY2Vo5YvJGqyHqXM6P4ppOYGsIRU8MM9pFQ==}
+  /@babel/types@7.24.7:
+    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.24.6
-      '@babel/helper-validator-identifier': 7.24.6
+      '@babel/helper-string-parser': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
     dev: false
 
@@ -579,8 +579,8 @@ packages:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: false
 
-  /@types/node@20.14.1:
-    resolution: {integrity: sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==}
+  /@types/node@20.14.2:
+    resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
     dependencies:
       undici-types: 5.26.5
 
@@ -601,7 +601,7 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.2.12(@types/node@20.14.1)
+      vite: 5.2.12(@types/node@20.14.2)
       vue: 3.4.27(typescript@5.4.5)
     dev: false
 
@@ -627,7 +627,7 @@ packages:
   /@vue/compiler-core@3.4.27:
     resolution: {integrity: sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==}
     dependencies:
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.24.7
       '@vue/shared': 3.4.27
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -644,7 +644,7 @@ packages:
   /@vue/compiler-sfc@3.4.27:
     resolution: {integrity: sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==}
     dependencies:
-      '@babel/parser': 7.24.6
+      '@babel/parser': 7.24.7
       '@vue/compiler-core': 3.4.27
       '@vue/compiler-dom': 3.4.27
       '@vue/compiler-ssr': 3.4.27
@@ -781,7 +781,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.23.0
-      caniuse-lite: 1.0.30001627
+      caniuse-lite: 1.0.30001629
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.1
@@ -829,8 +829,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001627
-      electron-to-chromium: 1.4.789
+      caniuse-lite: 1.0.30001629
+      electron-to-chromium: 1.4.792
       node-releases: 2.0.14
       update-browserslist-db: 1.0.16(browserslist@4.23.0)
     dev: true
@@ -845,8 +845,8 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /caniuse-lite@1.0.30001627:
-    resolution: {integrity: sha512-4zgNiB8nTyV/tHhwZrFs88ryjls/lHiqFhrxCW4qSTeuRByBVnPYpDInchOIySWknznucaf31Z4KYqjfbrecVw==}
+  /caniuse-lite@1.0.30001629:
+    resolution: {integrity: sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==}
     dev: true
 
   /chalk@4.1.2:
@@ -969,8 +969,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /electron-to-chromium@1.4.789:
-    resolution: {integrity: sha512-0VbyiaXoT++Fi2vHGo2ThOeS6X3vgRCWrjPeO2FeIAWL6ItiSJ9BqlH8LfCXe3X1IdcG+S0iLoNaxQWhfZoGzQ==}
+  /electron-to-chromium@1.4.792:
+    resolution: {integrity: sha512-rkg5/N3L+Y844JyfgPUyuKK0Hk0efo3JNxUDKvz3HgP6EmN4rNGhr2D8boLsfTV/hGo7ZGAL8djw+jlg99zQyA==}
     dev: true
 
   /emoji-regex@8.0.0:
@@ -1160,7 +1160,7 @@ packages:
     hasBin: true
     dependencies:
       foreground-child: 3.1.1
-      jackspeak: 3.3.0
+      jackspeak: 3.4.0
       minimatch: 9.0.4
       minipass: 7.1.2
       path-scurry: 1.11.1
@@ -1280,8 +1280,8 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /jackspeak@3.3.0:
-    resolution: {integrity: sha512-glPiBfKguqA7v8JsXO3iLjJWZ9FV1vNpoI0I9hI9Mnk5yetO9uPLSpiCEmiVijAssv2f54HpvtzvAHfhPieiDQ==}
+  /jackspeak@3.4.0:
+    resolution: {integrity: sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==}
     engines: {node: '>=14'}
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -1289,8 +1289,8 @@ packages:
       '@pkgjs/parseargs': 0.11.0
     dev: true
 
-  /jiti@1.21.1:
-    resolution: {integrity: sha512-KMXpzEJMsOFyRj6ZpDTnnlJrdr9umUY+eut5vlRvjVixohitnRFIRTFw9MEu9zPlBxTHZo6xD5ftKYiQZuJYQw==}
+  /jiti@1.21.3:
+    resolution: {integrity: sha512-uy2bNX5zQ+tESe+TiC7ilGRz8AtRGmnJH55NC5S0nSUjvvvM2hJHmefHErugGXN4pNv4Qx7vLsnNw9qJ9mtIsw==}
     hasBin: true
     dev: true
 
@@ -1630,7 +1630,7 @@ packages:
       picocolors: 1.0.1
       source-map-js: 1.2.0
 
-  /prettier-plugin-tailwindcss@0.5.14(prettier@3.3.0):
+  /prettier-plugin-tailwindcss@0.5.14(prettier@3.3.1):
     resolution: {integrity: sha512-Puaz+wPUAhFp8Lo9HuciYKM2Y2XExESjeT+9NQoVFXZsPPnc9VYss2SpxdQ6vbatmt8/4+SN0oe0I1cPDABg9Q==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
@@ -1682,11 +1682,11 @@ packages:
       prettier-plugin-svelte:
         optional: true
     dependencies:
-      prettier: 3.3.0
+      prettier: 3.3.1
     dev: true
 
-  /prettier@3.3.0:
-    resolution: {integrity: sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==}
+  /prettier@3.3.1:
+    resolution: {integrity: sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true
@@ -1923,8 +1923,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /tailwindcss@3.4.3:
-    resolution: {integrity: sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==}
+  /tailwindcss@3.4.4:
+    resolution: {integrity: sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
@@ -1936,7 +1936,7 @@ packages:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
       is-glob: 4.0.3
-      jiti: 1.21.1
+      jiti: 1.21.3
       lilconfig: 2.1.0
       micromatch: 4.0.7
       normalize-path: 3.0.0
@@ -2034,7 +2034,7 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /vite@5.2.12(@types/node@20.14.1):
+  /vite@5.2.12(@types/node@20.14.2):
     resolution: {integrity: sha512-/gC8GxzxMK5ntBwb48pR32GGhENnjtY30G4A0jemunsBkiEZFw60s8InGpN8gkhHEkjnRK1aSAxeQgwvFhUHAA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -2062,7 +2062,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.14.1
+      '@types/node': 20.14.2
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.18.0

--- a/src/main/client/index.ts
+++ b/src/main/client/index.ts
@@ -1,3 +1,4 @@
+import * as alt from 'alt-client';
 import './startup.js';
 import { useClientApi } from './api/index.js';
 
@@ -53,3 +54,12 @@ export function useRebarClient() {
         },
     };
 }
+
+declare module "alt-shared" {
+    // extending interface by interface merging
+    export interface ICustomGlobalMeta {
+        RebarClient: ReturnType<typeof useRebarClient>
+    }
+}
+
+alt.setMeta('RebarClient', useRebarClient());

--- a/src/main/server/index.ts
+++ b/src/main/server/index.ts
@@ -1,3 +1,4 @@
+import * as alt from 'alt-server';
 import './startup.js';
 
 import { useApi } from './api/index.js';
@@ -151,3 +152,12 @@ export function useRebar() {
         },
     };
 }
+
+declare module "alt-shared" {
+    // extending interface by interface merging
+    export interface ICustomGlobalMeta {
+        Rebar: ReturnType<typeof useRebar>
+    }
+}
+
+alt.setMeta('Rebar', useRebar());

--- a/src/main/shared/types/character.ts
+++ b/src/main/shared/types/character.ts
@@ -2,7 +2,7 @@ import * as alt from 'alt-shared';
 import { Appearance } from './appearance.js';
 import { ClothingComponent } from './clothingComponent.js';
 
-export type BaseCharacter = {
+export interface BaseCharacter {
     /**
      * The current dimension of the player. When they spawn
      * they are automatically moved into this dimension.
@@ -56,7 +56,7 @@ export type BaseCharacter = {
  *
  * @interface Character
  */
-export type Character = {
+export interface Character extends BaseCharacter {
     /**
      * The character identifier in the database.
      * @type {*}
@@ -185,4 +185,4 @@ export type Character = {
      * @type {{ [weaponHash: string]: number }}
      */
     ammo?: { [weaponHash: string]: number };
-} & BaseCharacter;
+};


### PR DESCRIPTION
## Version 17

### Code Changes

- Added `alt.getMeta('Rebar')` to get Server API with one-less import
- Added `alt.getMeta('RebarClient')` to get Client API with one-less import
- Fixed character interface not being extended correctly
- Added `preinstall` script to download binaries, and build codebase once
  
### Docs Changes

- Covered alternative API import methods in docs