### PR TITLE
18

### DIFF
--- a/docs/api/client/controllers/interaction.md
+++ b/docs/api/client/controllers/interaction.md
@@ -10,14 +10,16 @@ const interaction = useClientInteraction();
 // Listen for when the player enters a interaction
 interaction.onEnter(onEnter);
 
-function onEnter(uid: string, pos: alt.Vector3) {
+function onEnter(message: string, uid: string, pos: alt.Vector3) {
+    alt.log(message);
     alt.log(`UID: ${uid} | Pos: ${JSON.stringify(pos)}`);
 }
 
 // Listen for when the player leaves a interaction
 interaction.onLeave(onLeave);
 
-function onLeave(uid: string, pos: alt.Vector3) {
+function onLeave(message: string, uid: string, pos: alt.Vector3) {
+    alt.log(message);
     alt.log(`UID: ${uid} | Pos: ${JSON.stringify(pos)}`);
 }
 ```

--- a/docs/api/client/system/useProxyFetch.md
+++ b/docs/api/client/system/useProxyFetch.md
@@ -1,0 +1,12 @@
+# useProxyFetch
+
+This is the client version of the proxy fetch.
+
+Server requires APIs to be registered before they can be called.
+
+```ts
+const clientRebar = useRebarClient();
+const proxyFetch = clientRebar.useProxyFetch();
+
+const result = await proxyFetch.fetch('http://some-api-endpoint.com:3000');
+```

--- a/docs/api/server/controllers/peds.md
+++ b/docs/api/server/controllers/peds.md
@@ -1,0 +1,101 @@
+# usePed
+
+Peds use the internal alt:V Peds that can be synchronized by invoking a set of hand-picked natives on them.
+
+Default behavior:
+
+-   When a pedestrian dies, it's despawned after 5 seconds
+
+```ts
+const ped = Rebar.controllers.usePed(new alt.Ped('mp_m_freemode_01', new alt.Vector3(0, 0, 0), alt.Vector3.ZERO, 100));
+
+// Makes the ped not react to anything
+ped.setOption('makeStupid', true);
+
+// Makes the ped not take damage
+ped.setOption('invincible', true);
+
+// Invoke a native on the ped
+// This one shows you how to play a simple dance animation
+ped.invoke(
+    'taskPlayAnim',
+    'anim@amb@nightclub@mini@dance@dance_solo@female@var_a@',
+    'med_center_up',
+    8.0,
+    8.0,
+    -1,
+    1,
+    0,
+    false,
+    false,
+    false,
+);
+
+// Listen for when this pedestrian dies
+ped.onDeath((uid: string, killer: alt.Entity, weaponHash: number) => {
+    console.log(`${uid} died`);
+});
+
+// Check if the pedestrian is near a position by 3 range
+if (!ped.isNear(player.pos, 3)) {
+    console.log('not close to the player');
+}
+
+// Freezes the ped in place
+ped.setFrozen();
+
+// Freeze ped in place, and disable collision entirely
+ped.setNoCollision();
+
+// Straight up just kill the ped
+ped.kill();
+```
+
+## Native List
+
+These are the list of natives that are available to invoke.
+
+This can be updated later but this is a general purpose list that should work fine with the ped.
+
+```ts
+type PedNatives = Pick<
+    typeof native,
+    | 'clearPedTasks'
+    | 'clearPedTasksImmediately'
+    | 'getIsTaskActive'
+    | 'isEntityPlayingAnim'
+    | 'isPedArmed'
+    | 'isPedDeadOrDying'
+    | 'isPedInCover'
+    | 'isPedInVehicle'
+    | 'isPedStopped'
+    | 'taskAchieveHeading'
+    | 'taskAimGunAtCoord'
+    | 'taskAimGunAtEntity'
+    | 'taskClearLookAt'
+    | 'taskClimb'
+    | 'taskClimbLadder'
+    | 'taskCower'
+    | 'taskEnterVehicle'
+    | 'taskExitCover'
+    | 'taskGetOffBoat'
+    | 'taskGoStraightToCoord'
+    | 'taskGoToCoordAnyMeans'
+    | 'taskGoToEntity'
+    | 'taskLeaveAnyVehicle'
+    | 'taskOpenVehicleDoor'
+    | 'taskPatrol'
+    | 'taskPlayAnim'
+    | 'taskReloadWeapon'
+    | 'taskSeekCoverFromPos'
+    | 'taskShootAtCoord'
+    | 'taskShootAtEntity'
+    | 'taskStartScenarioInPlace'
+    | 'taskSynchronizedScene'
+    | 'taskUseMobilePhone'
+    | 'taskVehiclePark'
+    | 'taskWanderInArea'
+    | 'taskWanderSpecific'
+    | 'taskWanderStandard'
+>;
+```

--- a/docs/api/server/player/player-use.md
+++ b/docs/api/server/player/player-use.md
@@ -259,6 +259,26 @@ rebarPlayer.notify.sendMessage({ type: 'info', content: 'Hello there!' });
 rebarPlayer.notify.sendMessage({ type: 'player', content: 'Hello there!', author: 'Some Other Player' });
 ```
 
+## Raycast
+
+Used to get what the player is looking at, or find out other information
+
+```ts
+const rPlayer = Rebar.usePlayer(player);
+
+// Commonly used raycast functions
+const someVeh = await rPlayer.raycast.getFocusedEntity('vehicle');
+const somePlayer = await rPlayer.raycast.getFocusedEntity('player');
+const someAltvObject = await rPlayer.raycast.getFocusedEntity('object');
+
+// Get a world object and its position if available
+const someWorldObject = await rPlayer.raycast.getFocusedObject();
+console.log(someWorldObject.model, someWorldObject.pos, someWorldObject.scriptId);
+
+// Position where the player is looking, intersects with everything
+const somePos = await rPlayer.raycast.getFocusedPosition();
+```
+
 ## Player State
 
 Used to synchronize or apply weapons to a player.

--- a/docs/api/server/systems/useProxyFetch.md
+++ b/docs/api/server/systems/useProxyFetch.md
@@ -1,0 +1,24 @@
+# useProxyFetch
+
+Allows for you to register safe endpoints on server-side which can be called client-side, or server-side.
+
+Effectively calls an API from the server address, rather than the player address.
+
+```ts
+const proxyFetch = Rebar.useProxyFetch();
+
+// Get Register
+proxyFetch.register('http://some-api-url.com:3000', 'GET');
+
+// Get Usage
+const result = await proxyFetch.fetch('http://some-api-url.com:3000');
+
+// Post Auth
+proxyFetch.register('http://some-api-url.com:3000/auth', 'POST');
+
+// Post Usage
+const result = await proxyFetch.fetch('http://some-api-url.com:3000/auth', {
+    headers: { Authorization: 'bearer whatever' }, // Can pass tokens safely from server-side
+    body: JSON.stringify({ whatever: 'hi' }), // Can pass body data safely from server-side
+});
+```

--- a/docs/api/server/utility/protect-callback.md
+++ b/docs/api/server/utility/protect-callback.md
@@ -15,6 +15,17 @@ function handleEvent(player: alt.Player, arg1: string, arg2: string) {
 
 alt.onClient(
     'protected-event',
-    Rebar.utility.useProtectCallback(handleEvent, { account: ['admin'], character: ['police'] }),
+    Rebar.utility.useProtectCallback(handleEvent, {
+        // This checks if the account has a permission
+        account: ['admin'],
+
+        // This checks if a character has some other permission
+        character: ['do-something'],
+
+        // This checks if a player has a group permission
+        group: {
+            police: ['cadet'],
+        },
+    }),
 );
 ```

--- a/docs/api/server/vehicle/vehicle-use.md
+++ b/docs/api/server/vehicle/vehicle-use.md
@@ -7,21 +7,43 @@ import { useRebar } from '@Server/index.js';
 
 const Rebar = useRebar();
 
+const vehicle = new alt.Vehicle('infernus', alt.Vector3.zero, alt.Vector3.zero);
+const rVehicle = Rebar.vehicle.useVehicle(vehicle);
+
 // Used to apply mods, health, etc. to a vehicle if it has a document bound
-Rebar.vehicle.useVehicle(vehicle).sync();
+rVehicle.sync();
 
 // Use a document template to any given vehicle, does not save data
-Rebar.vehicle.useVehicle(vehicle).apply({ pos: new alt.Vector3(0, 0, 0) });
+rVehicle.apply({ pos: new alt.Vector3(0, 0, 0) });
 
 // Save all current damage, position, rotation etc.
 // This does not create a new document for the given vehicle
-Rebar.vehicle.useVehicle(vehicle).save();
+rVehicle.save();
 
 // Correctly repairs the vehicle and returns the new vehicle instance
 // Players will be removed from the vehicle on repair
-await Rebar.vehicle.useVehicle(vehicle).repair();
+await rVehicle.repair();
 
 // Creating a vehicle and assigning it to a character id, or some other identifier
-const newVehicle = new alt.Vehicle('infernus', alt.Vector3.zero, alt.Vector3.zero);
-const document = await Rebar.vehicle.useVehicle(newVehicle).create(someCharacterIdOrSomethingElse);
+const document = await rVehicle.create(someCharacterIdOrSomethingElse);
+
+// Toggle a door freely, or toggle as a player to check permission for vehicle
+rVehicle.toggleDoor(parseInt(id));
+rVehicle.toggleDoorAsPlayer(player, 1);
+
+// Toggle engine freely, or toggle as a player to check permission for vehicle
+rVehicle.toggleEngine();
+rVehicle.toggleEngineAsPlayer(player);
+
+// Toggle lock freely, or toggle as a player to check permission for vehicle
+rVehicle.toggleLock();
+rVehicle.toggleLockAsPlayer(player);
+
+// Check if a vehicle has a document bound to it
+rVehicle.isBound();
+
+// Add player to the vehicle, remove their id, or clear all keys
+const didAdd = await rVehicle.keys.add('some_document_id');
+const didRemove = await rVehicle.keys.remove('some_document_id');
+rVehicle.keys.clear();
 ```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,18 +4,53 @@ order: -5
 
 # Changelog
 
+## Version 18
+
+### Code Changes
+
+-   Fixed a bug where closest entity and target ids matched, when they were different types
+-   Fixed passing `message` on client-side for interaction onEnter callbacks
+-   Fixed character permission issues when using protected callbacks
+-   Added group permissions for protected callbacks
+-   Added `useProxyFetch` which allows for you to register safe endpoints on server-side which can be called client-side.
+    -   This effectively allows you to make requests from the server to safely get results.
+    -   Meaning that if you have an API which only allows your server to make requests, this is a way to invoke it safely.
+-   Added `useRaycast` to get entity aimed at from client-side and return it to the server
+    -   Can obtain position looking at
+    -   Can obtain player, vehicle, or alt.Object looked at
+    -   Can obtain model & position of world object looked at
+-   Added `useVehicle` enhancements
+    -   Functions that toggled asPlayer verify ownership of keys, permission, or owner itself of the vehicle
+    -   bind
+    -   toggleDoor
+    -   toggleDoorAsPlayer
+    -   toggleEngine
+    -   toggleEngineAsPlayer
+    -   toggleLock
+    -   toggleLockAsPlayer
+    -   keys: add, remove, clear
+    -   isBound
+        -   Check if the vehicle is already bound
+    -   verifyOwner
+        -   Check if the player is an 'owner' of the vehicle
+        -   Additionally, optional section to check if they are the sole owner of the vehicle
+
+### Docs Changes
+
+---
+
 ## Version 17
 
 ### Code Changes
 
-- Added `alt.getMeta('Rebar')` to get Server API with one-less import
-- Added `alt.getMeta('RebarClient')` to get Client API with one-less import
-- Fixed character interface not being extended correctly
-- Added `preinstall` script to download binaries, and build codebase once
-  
+-   Added `alt.getMeta('Rebar')` to get Server API with one-less import
+-   Added `alt.getMeta('RebarClient')` to get Client API with one-less import
+-   Fixed character interface not being extended correctly
+-   Added `preinstall` script to download binaries, and build codebase once
+
 ### Docs Changes
 
-- Covered alternative API import methods in docs
+-   Covered alternative API import methods in docs
 
 ---
 
@@ -23,26 +58,26 @@ order: -5
 
 ### Code Changes
 
-- Added `@Composables` path alias
-- Added `@Plugins` path alias
+-   Added `@Composables` path alias
+-   Added `@Plugins` path alias
 
 ### Docs Changes
 
-- Updated composables with `@Composables`
-- Updated `what is a plugin` with information about component / composable only plugins
+-   Updated composables with `@Composables`
+-   Updated `what is a plugin` with information about component / composable only plugins
 
 ## Version 15
 
 ### Code Changes
 
-- Update dependencies
-- Update `_id` in database functions to use a non-deprecated ObjectId handler
-- Added `useServerWeather` function to allow setting weather and weather forecast
-  - This does not automatically sync for players, it's just a global way to set the data
+-   Update dependencies
+-   Update `_id` in database functions to use a non-deprecated ObjectId handler
+-   Added `useServerWeather` function to allow setting weather and weather forecast
+    -   This does not automatically sync for players, it's just a global way to set the data
 
 ### Docs Changes
 
-- Added `useServerWeather` docs
+-   Added `useServerWeather` docs
 
 ---
 
@@ -50,13 +85,13 @@ order: -5
 
 ### Code Changes
 
-- Added `emitServerRpc` to Webview to retrieve data from server-side using normal `alt.onRpc` events.
-  - Yes, this means you don't have to do weird event bindings to get data now.
-- Added `emitClientRpc` to Webview to retrieve data from client-side.
+-   Added `emitServerRpc` to Webview to retrieve data from server-side using normal `alt.onRpc` events.
+    -   Yes, this means you don't have to do weird event bindings to get data now.
+-   Added `emitClientRpc` to Webview to retrieve data from client-side.
 
 ### Docs Changes
 
-- Added `emitServerRpc` and `emitClientRpc` to docs
+-   Added `emitServerRpc` and `emitClientRpc` to docs
 
 ---
 
@@ -64,12 +99,12 @@ order: -5
 
 ### Code Changes
 
-- Updated `upgrade` script to prevent overwriting tailwind config, or vite config
-- Added `useLocalStorage` composable for getting / storing data
+-   Updated `upgrade` script to prevent overwriting tailwind config, or vite config
+-   Added `useLocalStorage` composable for getting / storing data
 
 ### Docs Changes
 
-- Added `useLocalStorage` composable docs
+-   Added `useLocalStorage` composable docs
 
 ---
 
@@ -77,14 +112,14 @@ order: -5
 
 ### Code Changes
 
-- Completely redid the compile pipeline
-- Improved compile times, and added docker build support to package.json scripts
-- Fixed linux based errors
+-   Completely redid the compile pipeline
+-   Improved compile times, and added docker build support to package.json scripts
+-   Fixed linux based errors
 
 ### Docs Changes
 
-- Added install instructions for Linux
-- Added install instructions for Docker
+-   Added install instructions for Linux
+-   Added install instructions for Docker
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -34,6 +34,9 @@ order: -5
     -   verifyOwner
         -   Check if the player is an 'owner' of the vehicle
         -   Additionally, optional section to check if they are the sole owner of the vehicle
+-   Added new controller `usePed` which creates a global pedestrian which can have synced natives invoked on it
+    -   It's recommended not to spawn more than 32 given peds around a single player.
+    -   Can even easily listen to when the specific ped spawned dies
 
 ### Docs Changes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,11 @@ order: -5
 
 ### Docs Changes
 
+-   Added `useProxyFetch` doc
+-   Added `useRaycast` doc
+-   Added `useVehicle` updates
+-   Added `usePed` controller docs
+
 ---
 
 ## Version 17

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "author": "stuyk",
     "type": "module",
-    "version": "17",
+    "version": "18",
     "scripts": {
         "dev": "nodemon -x pnpm start",
         "dev:linux": "nodemon -x pnpm start:linux",
@@ -40,7 +40,7 @@
         "mongodb": "^6.7.0",
         "sjcl": "^1.0.8",
         "typescript": "^5.4.5",
-        "vite": "^5.2.12",
+        "vite": "^5.2.13",
         "vue": "^3.4.27",
         "vue-tsc": "^2.0.19"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   '@vitejs/plugin-vue':
     specifier: ^5.0.5
-    version: 5.0.5(vite@5.2.12)(vue@3.4.27)
+    version: 5.0.5(vite@5.2.13)(vue@3.4.27)
   dotenv:
     specifier: ^16.4.5
     version: 16.4.5
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^5.4.5
     version: 5.4.5
   vite:
-    specifier: ^5.2.12
-    version: 5.2.12(@types/node@20.14.2)
+    specifier: ^5.2.13
+    version: 5.2.13(@types/node@20.14.2)
   vue:
     specifier: ^3.4.27
     version: 3.4.27(typescript@5.4.5)
@@ -594,14 +594,14 @@ packages:
       '@types/webidl-conversions': 7.0.3
     dev: false
 
-  /@vitejs/plugin-vue@5.0.5(vite@5.2.12)(vue@3.4.27):
+  /@vitejs/plugin-vue@5.0.5(vite@5.2.13)(vue@3.4.27):
     resolution: {integrity: sha512-LOjm7XeIimLBZyzinBQ6OSm3UBCNVCpLkxGC0oWmm2YPzVZoxMsdvNVimLTBzpAnR9hl/yn1SHGuRfe6/Td9rQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.2.12(@types/node@20.14.2)
+      vite: 5.2.13(@types/node@20.14.2)
       vue: 3.4.27(typescript@5.4.5)
     dev: false
 
@@ -830,7 +830,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001629
-      electron-to-chromium: 1.4.792
+      electron-to-chromium: 1.4.795
       node-releases: 2.0.14
       update-browserslist-db: 1.0.16(browserslist@4.23.0)
     dev: true
@@ -969,8 +969,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /electron-to-chromium@1.4.792:
-    resolution: {integrity: sha512-rkg5/N3L+Y844JyfgPUyuKK0Hk0efo3JNxUDKvz3HgP6EmN4rNGhr2D8boLsfTV/hGo7ZGAL8djw+jlg99zQyA==}
+  /electron-to-chromium@1.4.795:
+    resolution: {integrity: sha512-hHo4lK/8wb4NUa+NJYSFyJ0xedNHiR6ylilDtb8NUW9d4dmBFmGiecYEKCEbti1wTNzbKXLfl4hPWEkAFbHYlw==}
     dev: true
 
   /emoji-regex@8.0.0:
@@ -2034,8 +2034,8 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /vite@5.2.12(@types/node@20.14.2):
-    resolution: {integrity: sha512-/gC8GxzxMK5ntBwb48pR32GGhENnjtY30G4A0jemunsBkiEZFw60s8InGpN8gkhHEkjnRK1aSAxeQgwvFhUHAA==}
+  /vite@5.2.13(@types/node@20.14.2):
+    resolution: {integrity: sha512-SSq1noJfY9pR3I1TUENL3rQYDQCFqgD+lM6fTRAM8Nv6Lsg5hDLaXkjETVeBt+7vZBCMoibD+6IWnT2mJ+Zb/A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:

--- a/src/main/client/controllers/index.ts
+++ b/src/main/client/controllers/index.ts
@@ -4,6 +4,7 @@ import './blip.js';
 import './interaction.js';
 import './marker.js';
 import './object.js';
+import './ped.js';
 import './textlabel.js';
 
 alt.log('Loaded Controllers');

--- a/src/main/client/controllers/interaction.ts
+++ b/src/main/client/controllers/interaction.ts
@@ -2,7 +2,7 @@ import * as alt from 'alt-client';
 import { Events } from '@Shared/events/index.js';
 import { useMessenger } from '../system/messenger.js';
 
-type InteractionCallback = (uid: string, pos: alt.Vector3) => void;
+type InteractionCallback = (message: string, uid: string, pos: alt.Vector3) => void;
 
 const messenger = useMessenger();
 const DEFAULT_COOLDOWN = 1000;
@@ -38,7 +38,7 @@ function handleKeyPress(key: alt.KeyCode) {
 
 function handleClear() {
     for (let cb of onLeaveCallbacks) {
-        cb(uid, pos);
+        cb(message, uid, pos);
     }
 
     uid = undefined;
@@ -50,21 +50,31 @@ function handleClear() {
 
 function handleSet(_uid: string, _message: string | undefined, _pos: alt.Vector3) {
     for (let cb of onEnterCallbacks) {
-        cb(uid, pos);
+        cb(message, uid, pos);
     }
 
     uid = _uid;
-    message = _message;
+    message = _message ?? 'No Message Set';
     pos = _pos;
 
     alt.on('keyup', handleKeyPress);
 }
 
 export function useClientInteraction() {
+    /**
+     * Recieve a callback about the interaction when entered
+     *
+     * @param {InteractionCallback} cb
+     */
     function onEnter(cb: InteractionCallback) {
         onEnterCallbacks.push(cb);
     }
 
+    /**
+     * Recieve a callback about the interaction when left
+     *
+     * @param {InteractionCallback} cb
+     */
     function onLeave(cb: InteractionCallback) {
         onLeaveCallbacks.push(cb);
     }

--- a/src/main/client/controllers/ped.ts
+++ b/src/main/client/controllers/ped.ts
@@ -1,0 +1,58 @@
+import * as alt from 'alt-client';
+import * as native from 'natives';
+import { Events } from '@Shared/events/index.js';
+
+alt.on('gameEntityCreate', (entity) => {
+    if (!(entity instanceof alt.Ped)) {
+        return;
+    }
+
+    if (entity.getStreamSyncedMeta('makeStupid')) {
+        native.disablePedPainAudio(entity, true);
+    }
+
+    if (entity.getStreamSyncedMeta('invincible')) {
+        native.setEntityInvincible(entity, true);
+    }
+});
+
+alt.everyTick(() => {
+    for (let ped of alt.Ped.streamedIn) {
+        if (ped.getStreamSyncedMeta('makeStupid')) {
+            native.setPedCanRagdoll(ped, false);
+            native.setBlockingOfNonTemporaryEvents(ped, true);
+        }
+        native.setPedResetFlag(ped, 458, true);
+        native.setPedResetFlag(ped, 64, true);
+        native.setPedResetFlag(ped, 249, true);
+    }
+});
+
+async function invoke(nativeName: string, ...args: any[]) {
+    if (nativeName === 'taskPlayAnim') {
+        const [ped, dict, name, enterPlayback, exitPlayback, duration, flag, rate, lockX, lockY, lockZ] = args;
+
+        await alt.Utils.requestAnimDict(args[1]);
+
+        for (let i = 0; i < 64; i++) {
+            await alt.Utils.wait(500);
+
+            if (native.isEntityPlayingAnim(ped, dict, name, 3)) {
+                break;
+            }
+
+            native[nativeName](ped, dict, name, enterPlayback, exitPlayback, duration, flag, rate, lockX, lockY, lockZ);
+        }
+
+        return;
+    }
+
+    native[nativeName](...args);
+}
+
+async function invokeRpc(nativeName: string, ...args: any[]) {
+    return native[nativeName](...args);
+}
+
+alt.onServer(Events.controllers.ped.invoke, invoke);
+alt.onRpc(Events.controllers.ped.invokeRpc, invokeRpc);

--- a/src/main/client/index.ts
+++ b/src/main/client/index.ts
@@ -18,6 +18,8 @@ import { useWebview } from './webview/index.js';
 import { getMinimap } from './utility/minimap/index.js';
 import { isNativeMenuOpen } from './menus/native/page.js';
 import { useMessenger } from './system/messenger.js';
+import { useProxyFetch } from './system/proxyFetch.js';
+import { useRaycast } from './system/raycasts.js';
 
 export function useRebarClient() {
     return {
@@ -43,7 +45,9 @@ export function useRebarClient() {
         },
         player: {
             useCamera,
+            useRaycast,
         },
+        useProxyFetch,
         utility: {
             math,
             text,
@@ -55,10 +59,10 @@ export function useRebarClient() {
     };
 }
 
-declare module "alt-shared" {
+declare module 'alt-shared' {
     // extending interface by interface merging
     export interface ICustomGlobalMeta {
-        RebarClient: ReturnType<typeof useRebarClient>
+        RebarClient: ReturnType<typeof useRebarClient>;
     }
 }
 

--- a/src/main/client/system/index.ts
+++ b/src/main/client/system/index.ts
@@ -3,6 +3,7 @@ import * as alt from 'alt-client';
 import './consoleCommand.js';
 import './native.js';
 import './notification.js';
+import './raycasts.js';
 import './stats.js';
 import './waypoint.js';
 

--- a/src/main/client/system/proxyFetch.ts
+++ b/src/main/client/system/proxyFetch.ts
@@ -1,0 +1,12 @@
+import * as alt from 'alt-client';
+import { Events } from '../../shared/events/index.js';
+
+export function useProxyFetch() {
+    async function fetch<T = Object>(endpoint: string, options?: RequestInit): Promise<T | undefined> {
+        return await alt.emitRpc(Events.systems.proxyFetch.fetch, endpoint, options);
+    }   
+
+    return {
+        fetch
+    }
+}

--- a/src/main/client/system/raycasts.ts
+++ b/src/main/client/system/raycasts.ts
@@ -1,0 +1,105 @@
+import * as alt from 'alt-client';
+import * as native from 'natives';
+import { Events } from '../../shared/events/index.js';
+import { getDirectionFromRotation } from '../utility/math/index.js';
+
+type ReturnTypes = {
+    player: alt.Player;
+    vehicle: alt.Vehicle;
+    object: alt.Object;
+};
+
+function performRaycast(flags: number = -1) {
+    const start = alt.getCamPos();
+    const forwardVector = getDirectionFromRotation(native.getFinalRenderedCamRot(2));
+    const end = new alt.Vector3(
+        start.x + forwardVector.x * 500,
+        start.y + forwardVector.y * 500,
+        start.z + forwardVector.z * 500,
+    );
+
+    const raycast = native.startExpensiveSynchronousShapeTestLosProbe(
+        start.x,
+        start.y,
+        start.z,
+        end.x,
+        end.y,
+        end.z,
+        flags,
+        alt.Player.local,
+        4,
+    );
+
+    const [result, didHit, coords, coords2, entity] = native.getShapeTestResult(raycast);
+    return { result, didHit, coords, coords2, entity };
+}
+
+export function useRaycast() {
+    /**
+     * Find an entity the player is looking at
+     *
+     * @template K
+     * @param {K} type
+     * @return {ReturnTypes[K]}
+     */
+    function getFocusedEntity<K extends keyof ReturnTypes>(type: K): ReturnTypes[K] {
+        const results = performRaycast();
+        if (!results.result || !results.didHit) {
+            return undefined;
+        }
+
+        if (type === 'player') {
+            return alt.Player.all.find((x) => x.scriptID === results.entity) as ReturnTypes[K];
+        }
+
+        if (type === 'vehicle') {
+            return alt.Vehicle.all.find((x) => x.scriptID === results.entity) as ReturnTypes[K];
+        }
+
+        if (type === 'object') {
+            return alt.Object.all.find((x) => x.scriptID === results.entity) as ReturnTypes[K];
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Get the object the player is looking at
+     *
+     * @return {{ pos: alt.Vector3; id: number; model: number }}
+     */
+    function getFocusedObject(): { pos: alt.Vector3; scriptId: number; model: number } {
+        const results = performRaycast(16);
+        if (!results.result || !results.didHit) {
+            return undefined;
+        }
+
+        return { pos: results.coords, scriptId: results.entity, model: native.getEntityModel(results.entity) };
+    }
+
+    /**
+     * Get the position the player is looking at
+     *
+     * @return {alt.Vector3}
+     */
+    function getFocusedPosition(): alt.Vector3 {
+        const results = performRaycast(-1);
+        if (!results.result || !results.didHit) {
+            return undefined;
+        }
+
+        return results.coords;
+    }
+
+    return {
+        getFocusedEntity,
+        getFocusedObject,
+        getFocusedPosition,
+    };
+}
+
+const raycast = useRaycast();
+
+alt.onRpc(Events.systems.raycast.getFocusedEntity, raycast.getFocusedEntity);
+alt.onRpc(Events.systems.raycast.getFocusedObject, raycast.getFocusedObject);
+alt.onRpc(Events.systems.raycast.getFocusedPosition, raycast.getFocusedPosition);

--- a/src/main/server/controllers/ped.ts
+++ b/src/main/server/controllers/ped.ts
@@ -1,0 +1,307 @@
+import * as alt from 'alt-server';
+import * as native from 'natives';
+import { PedOptions } from '@Shared/types/pedOptions.js';
+import { Events } from '../../shared/events/index.js';
+import * as Utility from '@Shared/utility/index.js';
+import { useRebar } from '../index.js';
+
+const sessionKey = 'ped:uid';
+
+type PedNatives = Pick<
+    typeof native,
+    | 'clearPedTasks'
+    | 'clearPedTasksImmediately'
+    | 'getIsTaskActive'
+    | 'isEntityPlayingAnim'
+    | 'isPedArmed'
+    | 'isPedDeadOrDying'
+    | 'isPedInCover'
+    | 'isPedInVehicle'
+    | 'isPedStopped'
+    | 'taskAchieveHeading'
+    | 'taskAimGunAtCoord'
+    | 'taskAimGunAtEntity'
+    | 'taskClearLookAt'
+    | 'taskClimb'
+    | 'taskClimbLadder'
+    | 'taskCower'
+    | 'taskEnterVehicle'
+    | 'taskExitCover'
+    | 'taskGetOffBoat'
+    | 'taskGoStraightToCoord'
+    | 'taskGoToCoordAnyMeans'
+    | 'taskGoToEntity'
+    | 'taskLeaveAnyVehicle'
+    | 'taskOpenVehicleDoor'
+    | 'taskPatrol'
+    | 'taskPlayAnim'
+    | 'taskReloadWeapon'
+    | 'taskSeekCoverFromPos'
+    | 'taskShootAtCoord'
+    | 'taskShootAtEntity'
+    | 'taskStartScenarioInPlace'
+    | 'taskSynchronizedScene'
+    | 'taskUseMobilePhone'
+    | 'taskVehiclePark'
+    | 'taskWanderInArea'
+    | 'taskWanderSpecific'
+    | 'taskWanderStandard'
+>;
+
+type OmitFirstArg<F> = F extends (x: any, ...args: infer P) => infer R ? (...args: P) => R : never;
+type PedDeathCallback = (uid: string, killer: alt.Entity, weaponHash: number) => void;
+
+const peds: Map<string, ReturnType<typeof usePed>> = new Map();
+
+export function usePed(ped: alt.Ped, uid?: string) {
+    const callbacks: Array<PedDeathCallback> = [];
+
+    if (!uid) {
+        uid = Utility.uid.generate();
+    }
+
+    ped.setMeta(sessionKey, uid);
+
+    function updateNetOwner() {
+        if (!ped.valid) {
+            return;
+        }
+
+        if (!ped.netOwner) {
+            const closestPlayer = getClosestPlayer();
+            if (!closestPlayer) {
+                return;
+            }
+
+            ped.setNetOwner(closestPlayer);
+        }
+    }
+
+    /**
+     * Set extra options on this ped
+     *
+     * @template K
+     * @param {K} option
+     * @param {boolean} value
+     */
+    function setOption<K extends keyof PedOptions>(option: K, value: boolean) {
+        if (!ped.valid) {
+            return;
+        }
+
+        ped.setStreamSyncedMeta(String(option), value);
+    }
+
+    /**
+     * Freeze the ped
+     */
+    function setFrozen() {
+        if (!ped.valid) {
+            return;
+        }
+
+        ped.frozen = true;
+    }
+
+    /**
+     * This turns off collision, and also freezes the ped
+     */
+    function setNoCollision() {
+        if (!ped.valid) {
+            return;
+        }
+
+        ped.frozen = true;
+        ped.collision = false;
+    }
+
+    /**
+     * Get closest player to the ped
+     *
+     * @return {alt.Player}
+     */
+    function getClosestPlayer(): alt.Player {
+        if (!ped.valid) {
+            return undefined;
+        }
+
+        if (alt.Player.all.length <= 0) {
+            return undefined;
+        }
+
+        let lastDist = ped.streamingDistance;
+        let closest: alt.Player;
+        for (let player of alt.Player.all) {
+            if (!player || !player.valid) {
+                continue;
+            }
+
+            const dist = Utility.vector.distance2d(player.pos, ped.pos);
+            if (dist > lastDist) {
+                continue;
+            }
+
+            lastDist = dist;
+            closest = player;
+        }
+
+        return closest;
+    }
+
+    /**
+     * Check if the ped is near a position
+     *
+     * @param {alt.Vector3} position
+     * @return
+     */
+    function isNear(position: alt.Vector3, distance = 2) {
+        if (!ped.valid) {
+            return false;
+        }
+
+        return Utility.vector.distance2d(ped.pos, position) <= distance;
+    }
+
+    /**
+     * Invoke a native on the ped
+     *
+     * @template K
+     * @param {K} native
+     * @param {...Parameters<OmitFirstArg<PedNatives[K]>>} args
+     * @return
+     */
+    function invoke<K extends keyof PedNatives>(native: K, ...args: Parameters<OmitFirstArg<PedNatives[K]>>) {
+        if (!ped.valid) {
+            return;
+        }
+
+        updateNetOwner();
+
+        if (!ped.netOwner || !ped.netOwner.valid) {
+            return;
+        }
+
+        ped.netOwner.emit(Events.controllers.ped.invoke, native, ped, ...args);
+    }
+
+    /**
+     * Invoke a native on the ped, and get a result back
+     *
+     * @template K
+     * @param {K} native
+     * @param {...Parameters<OmitFirstArg<PedNatives[K]>>} args
+     * @return {(Promise<ReturnType<PedNatives[K]> | undefined>)}
+     */
+    async function invokeRpc<K extends keyof PedNatives>(
+        native: K,
+        ...args: Parameters<OmitFirstArg<PedNatives[K]>>
+    ): Promise<ReturnType<PedNatives[K]> | undefined> {
+        if (!ped.valid) {
+            return undefined;
+        }
+
+        if (!ped.netOwner || !ped.netOwner.valid) {
+            return undefined;
+        }
+
+        return await ped.netOwner.emitRpc(Events.controllers.ped.invokeRpc, native, ped, ...args);
+    }
+
+    /**
+     * Listen for when this specific pedestrian dies
+     *
+     * @param {PedDeathCallback} cb
+     */
+    function onDeath(cb: PedDeathCallback) {
+        callbacks.push(cb);
+    }
+
+    /**
+     * Kill the pedestrian
+     *
+     */
+    function kill() {
+        ped.health = 0;
+    }
+
+    /**
+     * Internally handles invoking death on a player, they're removed after 5 seconds
+     *
+     * This function is called automatically
+     *
+     * @param {alt.Entity} killer
+     * @param {number} weaponHash
+     */
+    function invokeDeath(killer: alt.Entity, weaponHash: number) {
+        ped.health = 0;
+
+        for (let cb of callbacks) {
+            cb(uid, killer, weaponHash);
+        }
+
+        alt.setTimeout(() => {
+            if (!ped.valid) {
+                return;
+            }
+
+            ped.destroy();
+        }, 5000);
+    }
+
+    peds.set(uid, {
+        getClosestPlayer,
+        invoke,
+        invokeDeath,
+        invokeRpc,
+        isNear,
+        kill,
+        onDeath,
+        setFrozen,
+        setNoCollision,
+        setOption,
+    });
+
+    return {
+        getClosestPlayer,
+        invoke,
+        invokeRpc,
+        invokeDeath,
+        isNear,
+        kill,
+        onDeath,
+        setFrozen,
+        setNoCollision,
+        setOption,
+    };
+}
+
+alt.on('pedDeath', (ped, killer, weaponHash) => {
+    const uid = ped.getMeta(sessionKey) as string;
+    if (!uid) {
+        return;
+    }
+
+    if (!peds.has(uid)) {
+        return;
+    }
+
+    const pedHandler = peds.get(uid);
+    pedHandler.invokeDeath(killer, weaponHash);
+});
+
+alt.on('removeEntity', (entity: alt.Entity) => {
+    if (!(entity instanceof alt.Ped)) {
+        return;
+    }
+
+    const uid = entity.getMeta(sessionKey) as string;
+    if (!uid) {
+        return;
+    }
+
+    if (!peds.has(uid)) {
+        return;
+    }
+
+    peds.delete(uid);
+});

--- a/src/main/server/getters/shared.ts
+++ b/src/main/server/getters/shared.ts
@@ -18,7 +18,8 @@ export function getClosestEntity<T extends alt.Entity>(entity: alt.Entity, entit
             continue;
         }
 
-        if (target.id === entity.id) {
+        // Ignore same types, with same ids
+        if (entity.type === target.type && target.id === entity.id) {
             continue;
         }
 

--- a/src/main/server/getters/vehicle.ts
+++ b/src/main/server/getters/vehicle.ts
@@ -59,6 +59,15 @@ export function useVehicleGetter() {
     }
 
     /**
+     * Check if a vehicle with a given _id is already spawned
+     *
+     * @param {string} _id
+     */
+    function isSpawned(_id: string) {
+        return byDatabaseID(_id) ? true : false;
+    }
+
+    /**
      * Checks if a vehicle is within 3 distance of a position.
      *
      * @param {alt.Vehicle} vehicle An alt:V Vehicle Entity
@@ -111,6 +120,7 @@ export function useVehicleGetter() {
         driver,
         isValidModel,
         isNearPosition,
+        isSpawned,
         passengers,
     };
 }

--- a/src/main/server/index.ts
+++ b/src/main/server/index.ts
@@ -61,6 +61,7 @@ import { useProtectCallback } from './utility/protectCallback.js';
 import { useServerTime } from './systems/serverTime.js';
 import { useServerWeather } from './systems/serverWeather.js';
 import { useProxyFetch } from './systems/proxyFetch.js';
+import { usePed } from './controllers/ped.js';
 
 export function useRebar() {
     return {
@@ -77,6 +78,7 @@ export function useRebar() {
             useTextLabelGlobal,
             useTextLabelLocal,
             usePickupGlobal,
+            usePed,
         },
         database: {
             useDatabase,
@@ -155,10 +157,10 @@ export function useRebar() {
     };
 }
 
-declare module "alt-shared" {
+declare module 'alt-shared' {
     // extending interface by interface merging
     export interface ICustomGlobalMeta {
-        Rebar: ReturnType<typeof useRebar>
+        Rebar: ReturnType<typeof useRebar>;
     }
 }
 

--- a/src/main/server/index.ts
+++ b/src/main/server/index.ts
@@ -60,6 +60,7 @@ import { useVehicle } from './vehicle/index.js';
 import { useProtectCallback } from './utility/protectCallback.js';
 import { useServerTime } from './systems/serverTime.js';
 import { useServerWeather } from './systems/serverWeather.js';
+import { useProxyFetch } from './systems/proxyFetch.js';
 
 export function useRebar() {
     return {
@@ -136,6 +137,7 @@ export function useRebar() {
             usePermissionGroup,
         },
         usePlayer,
+        useProxyFetch,
         useServerTime,
         useServerWeather,
         utility: {

--- a/src/main/server/player/index.ts
+++ b/src/main/server/player/index.ts
@@ -14,6 +14,7 @@ import { useWorld } from './world.js';
 import { useCharacter } from '../document/character.js';
 import { usePlayerGetter } from '../getters/player.js';
 import { useVehicleGetter } from '../getters/vehicle.js';
+import { useRaycast } from './raycast.js';
 
 const playerGetter = usePlayerGetter();
 const vehicleGetter = useVehicleGetter();
@@ -27,9 +28,17 @@ export function usePlayer(player: alt.Player) {
         character: useCharacter(player),
         get: {
             closestPlayer: () => {
+                if (!player || !player.valid) {
+                    return undefined;
+                }
+
                 return playerGetter.closestToPlayer(player);
             },
             closestVehicle: () => {
+                if (!player || !player.valid) {
+                    return undefined;
+                }
+
                 return vehicleGetter.closestVehicle(player);
             },
         },
@@ -38,6 +47,7 @@ export function usePlayer(player: alt.Player) {
         },
         native: useNative(player),
         notify: useNotify(player),
+        raycast: useRaycast(player),
         state: useState(player),
         status: useStatus(player),
         waypoint: useWaypoint(player),

--- a/src/main/server/player/raycast.ts
+++ b/src/main/server/player/raycast.ts
@@ -36,5 +36,7 @@ export function useRaycast(player: alt.Player) {
 
     return {
         getFocusedEntity,
+        getFocusedObject,
+        getFocusedPosition,
     };
 }

--- a/src/main/server/player/raycast.ts
+++ b/src/main/server/player/raycast.ts
@@ -1,0 +1,40 @@
+import * as alt from 'alt-server';
+import { Events } from '../../shared/events/index.js';
+
+type ReturnTypes = {
+    player: alt.Player;
+    vehicle: alt.Vehicle;
+    object: alt.Object;
+};
+
+export function useRaycast(player: alt.Player) {
+    /**
+     * Returns the entity the player is looking at, or `undefined`.
+     *
+     * @template K
+     * @param {K} type
+     * @return {Promise<ReturnTypes[K]>}
+     */
+    async function getFocusedEntity<K extends keyof ReturnTypes>(type: K): Promise<ReturnTypes[K] | undefined> {
+        return await player.emitRpc(Events.systems.raycast.getFocusedEntity, type);
+    }
+
+    /**
+     * Get a world object the player may be looking at.
+     *
+     * **Keep in mind that `scriptId` is not the same for every player**
+     *
+     * @return {Promise<{ pos: alt.Vector3; scriptId: number; model: number }>}
+     */
+    async function getFocusedObject(): Promise<{ pos: alt.Vector3; scriptId: number; model: number } | undefined> {
+        return await player.emitRpc(Events.systems.raycast.getFocusedObject);
+    }
+
+    async function getFocusedPosition(): Promise<alt.Vector3 | undefined> {
+        return await player.emitRpc(Events.systems.raycast.getFocusedPosition);
+    }
+
+    return {
+        getFocusedEntity,
+    };
+}

--- a/src/main/server/player/webview.ts
+++ b/src/main/server/player/webview.ts
@@ -63,7 +63,7 @@ export function useWebview(player: alt.Player) {
         try {
             await alt.Utils.waitFor(() => {
                 const pages = player.getMeta(
-                    type === 'persistent' ? SessionKeys.WebviewPersistent : SessionKeys.WebviewOverlays
+                    type === 'persistent' ? SessionKeys.WebviewPersistent : SessionKeys.WebviewOverlays,
                 ) as PageInfo[];
 
                 const index = pages.findIndex((x) => x.name == pageName);
@@ -90,13 +90,13 @@ export function useWebview(player: alt.Player) {
 }
 
 alt.onClient(Events.player.webview.set.page, (player, pageName: string) =>
-    player.setMeta(SessionKeys.WebviewPage, pageName)
+    player.setMeta(SessionKeys.WebviewPage, pageName),
 );
 
 alt.onClient(Events.player.webview.set.overlays, (player, pageName: PageInfo[]) =>
-    player.setMeta(SessionKeys.WebviewOverlays, pageName)
+    player.setMeta(SessionKeys.WebviewOverlays, pageName),
 );
 
 alt.onClient(Events.player.webview.set.persistent, (player, pageName: PageInfo[]) =>
-    player.setMeta(SessionKeys.WebviewPersistent, pageName)
+    player.setMeta(SessionKeys.WebviewPersistent, pageName),
 );

--- a/src/main/server/systems/proxyFetch.ts
+++ b/src/main/server/systems/proxyFetch.ts
@@ -1,0 +1,57 @@
+import * as alt from 'alt-server';
+import { Events } from '../../shared/events/index.js';
+
+const safeEndpoints: {[key: string]: 'GET' | 'POST' } = {};
+
+export function useProxyFetch() {
+    /**
+     * Register a proxy fetch which can safely be fetched from client-side, and for general usage
+     *
+     * @param {string} endpoint 
+     * @param {('GET' | 'POST')} type 
+     */
+    function register(endpoint: string, type: 'GET' | 'POST') {
+        safeEndpoints[endpoint] = type;
+    }
+
+    /**
+     * Invoke a proxy fetch
+     *
+     * @param {string} endpoint 
+     * @param {RequestInit} [options] 
+     * @return 
+     */
+    async function fetch(endpoint: string, options?: RequestInit) {
+        if (!safeEndpoints[endpoint]) {
+            alt.logWarning(`${endpoint} is not registered and is considered an unsafe endpoint`)
+        }
+
+        if (!options) {
+            options = {};
+        }
+
+        options.method = safeEndpoints[endpoint];
+
+        const response = await fetch(endpoint, options);
+        if (!response.ok) {
+            return undefined;
+        }
+
+        try {
+            return response.json();
+        } catch(err) {
+            console.error(err);
+        }
+
+        return undefined;
+    }
+
+    return {
+        fetch,
+        register
+    }
+}
+
+alt.onRpc(Events.systems.proxyFetch.fetch, async (player: alt.Player, endpoint: string, options?: RequestInit) => { 
+    return await useProxyFetch().fetch(endpoint, options);
+});

--- a/src/main/server/vehicle/index.ts
+++ b/src/main/server/vehicle/index.ts
@@ -113,6 +113,35 @@ export function useVehicle(vehicle: alt.Vehicle) {
     }
 
     /**
+     * Bind a document to this vehicle
+     *
+     * Returns `true` if bound successfully
+     *
+     * @param {Vehicle} document
+     */
+    function bind(document: Vehicle) {
+        if (vehicle.model !== document.model) {
+            return false;
+        }
+
+        if (Rebar.document.vehicle.useVehicle(vehicle).get()) {
+            return false;
+        }
+
+        Rebar.document.vehicle.useVehicleBinder(vehicle).bind(document);
+        return true;
+    }
+
+    /**
+     * Check if the vehicle already has a bound document
+     *
+     * @return
+     */
+    function isBound() {
+        return Rebar.document.vehicle.useVehicle(vehicle).get() ? true : false;
+    }
+
+    /**
      * Despawns current vehicle, grabs existing document on the vehicle.
      * Recreates the vehicle, saves health, and then re-applies the document.
      *
@@ -202,6 +231,202 @@ export function useVehicle(vehicle: alt.Vehicle) {
     }
 
     /**
+     * Determine if this vehicle has an owner
+     *
+     * @return
+     */
+    function hasOwner() {
+        const document = Rebar.document.vehicle.useVehicle(vehicle);
+        return document.get() ? true : false;
+    }
+
+    /**
+     * Toggle door state for the given vehicle
+     *
+     * 0 - Driver
+     * 1 - Passenger
+     * 2 - Back Left
+     * 3 - Back Right
+     * 4 - Hood
+     * 5 - Trunk
+     *
+     * @param {number} door
+     */
+    function toggleDoor(door: number) {
+        vehicle.setDoorState(door, vehicle.getDoorState(door) === 0 ? 7 : 0);
+    }
+
+    /**
+     * Toggle the door as a player, check ownership
+     *
+     * @param {alt.Player} player
+     * @param {number} door
+     * @return
+     */
+    function toggleDoorAsPlayer(player: alt.Player, door: number) {
+        if (!verifyOwner(player, true)) {
+            return;
+        }
+
+        toggleDoor(door);
+    }
+
+    /**
+     * Toggle the engine on and off
+     */
+    function toggleEngine() {
+        vehicle.engineOn = !vehicle.engineOn;
+    }
+
+    /**
+     * Toggle the engine as a player, check ownership
+     *
+     * @param {alt.Player} player
+     * @return
+     */
+    function toggleEngineAsPlayer(player: alt.Player) {
+        if (!verifyOwner(player, true)) {
+            return;
+        }
+
+        toggleEngine();
+    }
+
+    /**
+     * Toggle the vehicle lock from locked to unlocked
+     */
+    function toggleLock() {
+        const LOCKED = 2;
+        const UNLOCKED = 1;
+        vehicle.lockState = vehicle.lockState === LOCKED ? UNLOCKED : LOCKED;
+    }
+
+    /**
+     * Toggle the door locks as a player, check ownership
+     *
+     * @param {alt.Player} player
+     * @return
+     */
+    function toggleLockAsPlayer(player: alt.Player) {
+        if (!verifyOwner(player, true)) {
+            return;
+        }
+
+        toggleLock();
+    }
+
+    /**
+     * Add a player who has keys to this vehicle
+     *
+     * @param {string} owner_document_id
+     * @return
+     */
+    async function addKey(owner_document_id: string) {
+        const document = Rebar.document.vehicle.useVehicle(vehicle);
+        if (!document.get()) {
+            return false;
+        }
+
+        const keys: string[] = document.getField('keys') ?? [];
+        const index = keys.findIndex((x) => x === owner_document_id);
+        if (index >= 0) {
+            return false;
+        }
+
+        keys.push(owner_document_id);
+        await document.set('keys', keys);
+        return true;
+    }
+
+    /**
+     * Remove a player who has keys to this vehicle
+     *
+     * @param {string} owner_document_id
+     * @return
+     */
+    async function removeKey(owner_document_id: string) {
+        const document = Rebar.document.vehicle.useVehicle(vehicle);
+        if (!document.get()) {
+            return false;
+        }
+
+        const keys: string[] = document.getField('keys') ?? [];
+        const index = keys.findIndex((x) => x === owner_document_id);
+        if (index <= -1) {
+            return false;
+        }
+
+        keys.splice(index, 1);
+        await document.set('keys', keys);
+        return true;
+    }
+
+    /**
+     * Clear all keys for this vehicle
+     *
+     * @return
+     */
+    async function clearKeys() {
+        const document = Rebar.document.vehicle.useVehicle(vehicle);
+        if (!document.get()) {
+            return false;
+        }
+
+        await document.set('keys', []);
+        return true;
+    }
+
+    /**
+     * Verify ownership of the vehicle by checking the owner identifier, or keys.
+     *
+     * If `requireOwnership` is set to true, then a non-owned vehicle will return false.
+     *
+     * Otherwise it will return `true`.
+     *
+     * @param {alt.Player} player
+     */
+    function verifyOwner(player: alt.Player, requireOwnership: boolean, ownerOnly = false) {
+        const document = Rebar.document.vehicle.useVehicle(vehicle);
+        if (!document.get()) {
+            return requireOwnership ? false : true;
+        }
+
+        const rPlayer = Rebar.usePlayer(player);
+        const _id = rPlayer.character.getField('_id');
+        if (!_id) {
+            return false;
+        }
+
+        // Verify ownership directly
+        const owner: string = document.getField('owner');
+        if (owner && owner === _id) {
+            return true;
+        }
+
+        if (ownerOnly) {
+            return false;
+        }
+
+        // Verify any matching keys
+        const keys: string[] = document.getField('keys') ?? [];
+        if (keys && keys.includes(_id)) {
+            return true;
+        }
+
+        // Verify any matching permissions
+        if (owner) {
+            const permissions: string[] = rPlayer.character.getField('permissions') ?? [];
+            for (let perm of permissions) {
+                if (owner === perm) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * If the vehicle has a `document` bound to it, it will apply the appearance.
      */
     function sync() {
@@ -215,5 +440,26 @@ export function useVehicle(vehicle: alt.Vehicle) {
         apply(data);
     }
 
-    return { apply, create, repair, save, sync };
+    return {
+        apply,
+        bind,
+        create,
+        hasOwner,
+        isBound,
+        keys: {
+            add: addKey,
+            remove: removeKey,
+            clear: clearKeys,
+        },
+        repair,
+        save,
+        sync,
+        toggleDoor,
+        toggleDoorAsPlayer,
+        toggleEngine,
+        toggleEngineAsPlayer,
+        toggleLock,
+        toggleLockAsPlayer,
+        verifyOwner,
+    };
 }

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -90,6 +90,14 @@ export const Events = {
         waypoint: {
             get: 'systems:waypoint:get',
         },
+        proxyFetch: {
+            fetch: 'systems:proxy:fetch',
+        },
+        raycast: {
+            getFocusedEntity: 'systems:raycast:get:focused:entity',
+            getFocusedPosition: 'systems:raycast:get:focused:position',
+            getFocusedObject: 'systems:raycast:get:focused:object',
+        },
     },
     view: {
         onServer: 'webview:on:server',
@@ -110,6 +118,6 @@ export const Events = {
         updateMinimap: 'webview:update:minimap',
         localStorageSet: 'webview:localstorage:set',
         localStorageGet: 'webview:localstorage:get',
-        localStorageDelete: 'webview:localstorage:delete'
+        localStorageDelete: 'webview:localstorage:delete',
     },
 };

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -17,6 +17,10 @@ export const Events = {
             create: 'object:create',
             destroy: 'object:destroy',
         },
+        ped: {
+            invoke: 'ped:invoke',
+            invokeRpc: 'ped:invoke:rpc',
+        },
         textlabel: {
             create: 'textlabel:create',
             destroy: 'textlabel:destroy',

--- a/src/main/shared/types/pedOptions.ts
+++ b/src/main/shared/types/pedOptions.ts
@@ -1,0 +1,17 @@
+export interface PedOptions {
+    /**
+     * Make the ped invincible
+     *
+     * @type {boolean}
+     * @memberof PedOptions
+     */
+    invincible: boolean;
+
+    /**
+     * Make the ped do literally nothing when interacted with
+     *
+     * @type {boolean}
+     * @memberof PedOptions
+     */
+    makeStupid: boolean;
+}


### PR DESCRIPTION
## Version 18

### Code Changes

-   Fixed a bug where closest entity and target ids matched, when they were different types
-   Fixed passing `message` on client-side for interaction onEnter callbacks
-   Fixed character permission issues when using protected callbacks
-   Added group permissions for protected callbacks
-   Added `useProxyFetch` which allows for you to register safe endpoints on server-side which can be called client-side.
    -   This effectively allows you to make requests from the server to safely get results.
    -   Meaning that if you have an API which only allows your server to make requests, this is a way to invoke it safely.
-   Added `useRaycast` to get entity aimed at from client-side and return it to the server
    -   Can obtain position looking at
    -   Can obtain player, vehicle, or alt.Object looked at
    -   Can obtain model & position of world object looked at
-   Added `useVehicle` enhancements
    -   Functions that toggled asPlayer verify ownership of keys, permission, or owner itself of the vehicle
    -   bind
    -   toggleDoor
    -   toggleDoorAsPlayer
    -   toggleEngine
    -   toggleEngineAsPlayer
    -   toggleLock
    -   toggleLockAsPlayer
    -   keys: add, remove, clear
    -   isBound
        -   Check if the vehicle is already bound
    -   verifyOwner
        -   Check if the player is an 'owner' of the vehicle
        -   Additionally, optional section to check if they are the sole owner of the vehicle
-   Added new controller `usePed` which creates a global pedestrian which can have synced natives invoked on it
    -   It's recommended not to spawn more than 32 given peds around a single player.
    -   Can even easily listen to when the specific ped spawned dies