### PR TITLE
feat: debug for raycast, raycast changes, small api changes

### DIFF
--- a/docs/api/server/api/plugin-api.md
+++ b/docs/api/server/api/plugin-api.md
@@ -54,19 +54,6 @@ useApi().register('my-cool-api', useMyCoolAPI());
 
 This is all that's necessary to start working with other plugin APIs.
 
-Below is dependent on load order, so your mileage may vary.
-
-```ts
-import { useRebar } from '@Server/index.js';
-
-const Rebar = useRebar();
-const myCoolAPI = Rebar.useApi().get('my-cool-api');
-
-function someFunction(somePlayer: alt.Player) {
-    myCoolAPI.logPlayerName(somePlayer);
-}
-```
-
 If you do not want to worry about load order. Consider the following pattern:
 
 ```ts

--- a/docs/api/server/player/player-use.md
+++ b/docs/api/server/player/player-use.md
@@ -269,14 +269,14 @@ const rPlayer = Rebar.usePlayer(player);
 // Commonly used raycast functions
 const someVeh = await rPlayer.raycast.getFocusedEntity('vehicle');
 const somePlayer = await rPlayer.raycast.getFocusedEntity('player');
-const someAltvObject = await rPlayer.raycast.getFocusedEntity('object');
+const someAltvObject = await rPlayer.raycast.getFocusedEntity('object', true); // Adding true draws a debug line in-game
 
-// Get a world object and its position if available
-const someWorldObject = await rPlayer.raycast.getFocusedObject();
-console.log(someWorldObject.model, someWorldObject.pos, someWorldObject.scriptId);
+// Get a world object, the raycast hit position, and the entity position
+const someWorldObject = await rPlayer.raycast.getFocusedObject(false); // Passing `true` draws a debug line in-game
+console.log(someWorldObject.model, someWorldObject.pos, someWorldObject.scriptId, someWorldObject.entityPos);
 
 // Position where the player is looking, intersects with everything
-const somePos = await rPlayer.raycast.getFocusedPosition();
+const somePos = await rPlayer.raycast.getFocusedPosition(false); // Passing `true` draws a debug line in-game
 ```
 
 ## Player State

--- a/docs/api/server/systems/useServerConfig.md
+++ b/docs/api/server/systems/useServerConfig.md
@@ -1,0 +1,28 @@
+# useServerConfig
+
+The server config controls player-wide aspects such as radar display, vehicle class display, etc.
+
+```ts
+const serverConfig = Rebar.useServerConfig();
+
+// Hide area name when moving around the world
+serverConfig.set('hideAreaName', true);
+
+// Hide health and armour on radar
+serverConfig.set('hideHealthArmour', true);
+
+// Hide minimap when a page is opened
+serverConfig.set('hideMinimapInPage', true);
+
+// Hide minimap when a player is on foot
+serverConfig.set('hideMinimapOnFoot', true);
+
+// Hide street name
+serverConfig.set('hideStreetName', true);
+
+// Hide vehicle class when entering a vehicle
+serverConfig.set('hideVehicleClass', true);
+
+// Hide vehicle name when entering a vehicle
+serverConfig.set('hideVehicleName', true);
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,11 +8,13 @@
 -   Clearly warn users using `api.get` for obtaining an API, and recommend async instead
 -   Added new `getMeta` API for getting plugin API as single import
 -   Added `debug` option to `raycast` functions to draw lines when a raycast is invoked
+-   Added `useServerConfig` to change what HUD elements, and other on screen elements a player sees
 
 ### Docs Changes
 
 -   Added `debug` to raycast docs
 -   Removed `get` from Plugin API examples, to let users focus on `async` instead
+-   Added `useServerConfig` to docs
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Version 20
+
+### Code Changes
+
+-   Made `raycast.getFocusedObject()` return `entityPos`
+-   Clearly warn users using `api.get` for obtaining an API, and recommend async instead
+-   Added new `getMeta` API for getting plugin API as single import
+-   Added `debug` option to `raycast` functions to draw lines when a raycast is invoked
+
+### Docs Changes
+
+-   Added `debug` to raycast docs
+-   Removed `get` from Plugin API examples, to let users focus on `async` instead
+
+---
+
 ## Version 19
 
 ### Code Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "author": "stuyk",
     "type": "module",
-    "version": "19",
+    "version": "20",
     "scripts": {
         "dev": "nodemon -x pnpm start",
         "dev:linux": "nodemon -x pnpm start:linux",
@@ -42,7 +42,7 @@
         "typescript": "^5.4.5",
         "vite": "^5.2.13",
         "vue": "^3.4.27",
-        "vue-tsc": "^2.0.19"
+        "vue-tsc": "^2.0.21"
     },
     "prettier": {
         "tabWidth": 4,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^3.4.27
     version: 3.4.27(typescript@5.4.5)
   vue-tsc:
-    specifier: ^2.0.19
-    version: 2.0.19(typescript@5.4.5)
+    specifier: ^2.0.21
+    version: 2.0.21(typescript@5.4.5)
 
 devDependencies:
   '@altv/types-client':
@@ -605,23 +605,24 @@ packages:
       vue: 3.4.27(typescript@5.4.5)
     dev: false
 
-  /@volar/language-core@2.2.5:
-    resolution: {integrity: sha512-2htyAuxRrAgETmFeUhT4XLELk3LiEcqoW/B8YUXMF6BrGWLMwIR09MFaZYvrA2UhbdAeSyeQ726HaWSWkexUcQ==}
+  /@volar/language-core@2.3.0:
+    resolution: {integrity: sha512-pvhL24WUh3VDnv7Yw5N1sjhPtdx7q9g+Wl3tggmnkMcyK8GcCNElF2zHiKznryn0DiUGk+eez/p2qQhz+puuHw==}
     dependencies:
-      '@volar/source-map': 2.2.5
+      '@volar/source-map': 2.3.0
     dev: false
 
-  /@volar/source-map@2.2.5:
-    resolution: {integrity: sha512-wrOEIiZNf4E+PWB0AxyM4tfhkfldPsb3bxg8N6FHrxJH2ohar7aGu48e98bp3pR9HUA7P/pR9VrLmkTrgCCnWQ==}
+  /@volar/source-map@2.3.0:
+    resolution: {integrity: sha512-G/228aZjAOGhDjhlyZ++nDbKrS9uk+5DMaEstjvzglaAw7nqtDyhnQAsYzUg6BMP9BtwZ59RIw5HGePrutn00Q==}
     dependencies:
       muggle-string: 0.4.1
     dev: false
 
-  /@volar/typescript@2.2.5:
-    resolution: {integrity: sha512-eSV/n75+ppfEVugMC/salZsI44nXDPAyL6+iTYCNLtiLHGJsnMv9GwiDMujrvAUj/aLQyqRJgYtXRoxop2clCw==}
+  /@volar/typescript@2.3.0:
+    resolution: {integrity: sha512-PtUwMM87WsKVeLJN33GSTUjBexlKfKgouWlOUIv7pjrOnTwhXHZNSmpc312xgXdTjQPpToK6KXSIcKu9sBQ5LQ==}
     dependencies:
-      '@volar/language-core': 2.2.5
+      '@volar/language-core': 2.3.0
       path-browserify: 1.0.1
+      vscode-uri: 3.0.8
     dev: false
 
   /@vue/compiler-core@3.4.27:
@@ -662,15 +663,15 @@ packages:
       '@vue/shared': 3.4.27
     dev: false
 
-  /@vue/language-core@2.0.19(typescript@5.4.5):
-    resolution: {integrity: sha512-A9EGOnvb51jOvnCYoRLnMP+CcoPlbZVxI9gZXE/y2GksRWM6j/PrLEIC++pnosWTN08tFpJgxhSS//E9v/Sg+Q==}
+  /@vue/language-core@2.0.21(typescript@5.4.5):
+    resolution: {integrity: sha512-vjs6KwnCK++kIXT+eI63BGpJHfHNVJcUCr3RnvJsccT3vbJnZV5IhHR2puEkoOkIbDdp0Gqi1wEnv3hEd3WsxQ==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@volar/language-core': 2.2.5
+      '@volar/language-core': 2.3.0
       '@vue/compiler-dom': 3.4.27
       '@vue/shared': 3.4.27
       computeds: 0.0.1
@@ -780,7 +781,7 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.1
       caniuse-lite: 1.0.30001629
       fraction.js: 4.3.7
       normalize-range: 0.1.2
@@ -824,15 +825,15 @@ packages:
       fill-range: 7.1.1
     dev: true
 
-  /browserslist@4.23.0:
-    resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
+  /browserslist@4.23.1:
+    resolution: {integrity: sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001629
-      electron-to-chromium: 1.4.795
+      electron-to-chromium: 1.4.796
       node-releases: 2.0.14
-      update-browserslist-db: 1.0.16(browserslist@4.23.0)
+      update-browserslist-db: 1.0.16(browserslist@4.23.1)
     dev: true
 
   /bson@6.7.0:
@@ -969,8 +970,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /electron-to-chromium@1.4.795:
-    resolution: {integrity: sha512-hHo4lK/8wb4NUa+NJYSFyJ0xedNHiR6ylilDtb8NUW9d4dmBFmGiecYEKCEbti1wTNzbKXLfl4hPWEkAFbHYlw==}
+  /electron-to-chromium@1.4.796:
+    resolution: {integrity: sha512-NglN/xprcM+SHD2XCli4oC6bWe6kHoytcyLKCWXmRL854F0qhPhaYgUswUsglnPxYaNQIg2uMY4BvaomIf3kLA==}
     dev: true
 
   /emoji-regex@8.0.0:
@@ -1597,7 +1598,7 @@ packages:
     dependencies:
       lilconfig: 3.1.1
       postcss: 8.4.38
-      yaml: 2.4.3
+      yaml: 2.4.5
     dev: true
 
   /postcss-nested@6.0.1(postcss@8.4.38):
@@ -2019,13 +2020,13 @@ packages:
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  /update-browserslist-db@1.0.16(browserslist@4.23.0):
+  /update-browserslist-db@1.0.16(browserslist@4.23.1):
     resolution: {integrity: sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.23.0
+      browserslist: 4.23.1
       escalade: 3.1.2
       picocolors: 1.0.1
     dev: true
@@ -2070,6 +2071,10 @@ packages:
       fsevents: 2.3.3
     dev: false
 
+  /vscode-uri@3.0.8:
+    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+    dev: false
+
   /vue-template-compiler@2.7.16:
     resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
     dependencies:
@@ -2077,14 +2082,14 @@ packages:
       he: 1.2.0
     dev: false
 
-  /vue-tsc@2.0.19(typescript@5.4.5):
-    resolution: {integrity: sha512-JWay5Zt2/871iodGF72cELIbcAoPyhJxq56mPPh+M2K7IwI688FMrFKc/+DvB05wDWEuCPexQJ6L10zSwzzapg==}
+  /vue-tsc@2.0.21(typescript@5.4.5):
+    resolution: {integrity: sha512-E6x1p1HaHES6Doy8pqtm7kQern79zRtIewkf9fiv7Y43Zo4AFDS5hKi+iHi2RwEhqRmuiwliB1LCEFEGwvxQnw==}
     hasBin: true
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@volar/typescript': 2.2.5
-      '@vue/language-core': 2.0.19(typescript@5.4.5)
+      '@volar/typescript': 2.3.0
+      '@vue/language-core': 2.0.21(typescript@5.4.5)
       semver: 7.6.2
       typescript: 5.4.5
     dev: false
@@ -2172,8 +2177,8 @@ packages:
         optional: true
     dev: true
 
-  /yaml@2.4.3:
-    resolution: {integrity: sha512-sntgmxj8o7DE7g/Qi60cqpLBA3HG3STcDA0kO+WfB05jEKhZMbY7umNm2rBpQvsmZ16/lPXCJGW2672dgOUkrg==}
+  /yaml@2.4.5:
+    resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
     engines: {node: '>= 14'}
     hasBin: true
     dev: true

--- a/src/main/client/index.ts
+++ b/src/main/client/index.ts
@@ -62,8 +62,25 @@ export function useRebarClient() {
 declare module 'alt-shared' {
     // extending interface by interface merging
     export interface ICustomGlobalMeta {
+        /**
+         * Only available client-side, client folder
+         *
+         * @type {ReturnType<typeof useRebarClient>}
+         * @memberof ICustomGlobalMeta
+         */
         RebarClient: ReturnType<typeof useRebarClient>;
+
+        /**
+         * Used for getting plugin APIs
+         *
+         * Only available client-side, client folder
+         *
+         * @type {ReturnType<typeof useClientApi>}
+         * @memberof ICustomGlobalMeta
+         */
+        RebarClientPluginAPI: ReturnType<typeof useClientApi>;
     }
 }
 
 alt.setMeta('RebarClient', useRebarClient());
+alt.setMeta('RebarClientPluginAPI', useRebarClient().useClientApi());

--- a/src/main/client/index.ts
+++ b/src/main/client/index.ts
@@ -84,3 +84,5 @@ declare module 'alt-shared' {
 
 alt.setMeta('RebarClient', useRebarClient());
 alt.setMeta('RebarClientPluginAPI', useRebarClient().useClientApi());
+
+alt.getMeta('');

--- a/src/main/client/system/index.ts
+++ b/src/main/client/system/index.ts
@@ -4,6 +4,7 @@ import './consoleCommand.js';
 import './native.js';
 import './notification.js';
 import './raycasts.js';
+import './serverConfig.js';
 import './stats.js';
 import './waypoint.js';
 

--- a/src/main/client/system/serverConfig.ts
+++ b/src/main/client/system/serverConfig.ts
@@ -1,0 +1,46 @@
+import * as alt from 'alt-client';
+import * as native from 'natives';
+import { useWebview } from '../webview/index.js';
+
+function tick() {
+    const config = alt.getMeta('ServerConfig');
+    if (!config) {
+        return;
+    }
+
+    if (config.hideHealthArmour) {
+        alt.beginScaleformMovieMethodMinimap('SETUP_HEALTH_ARMOUR');
+        native.scaleformMovieMethodAddParamInt(3);
+        native.endScaleformMovieMethod();
+    }
+
+    if (config.hideVehicleName) {
+        native.hideHudComponentThisFrame(6);
+    }
+
+    if (config.hideVehicleClass) {
+        native.hideHudComponentThisFrame(8);
+    }
+
+    if (config.hideStreetName) {
+        native.hideHudComponentThisFrame(9);
+    }
+
+    if (config.hideAreaName) {
+        native.hideHudComponentThisFrame(7);
+    }
+
+    let finalRadarState = true;
+
+    if (config.hideMinimapOnFoot) {
+        finalRadarState = alt.Player.local.vehicle ? false : true;
+    }
+
+    if (config.hideMinimapInPage && useWebview().isAnyPageOpen()) {
+        finalRadarState = false;
+    }
+
+    native.displayRadar(finalRadarState);
+}
+
+alt.everyTick(tick);

--- a/src/main/client/system/serverConfig.ts
+++ b/src/main/client/system/serverConfig.ts
@@ -1,12 +1,14 @@
 import * as alt from 'alt-client';
 import * as native from 'natives';
 import { useWebview } from '../webview/index.js';
+import { ServerConfig } from '../../shared/types/serverConfig.js';
+import { Events } from '../../shared/events/index.js';
+
+let config: ServerConfig = {};
+let lastRadarState = true;
 
 function tick() {
-    const config = alt.getMeta('ServerConfig');
-    if (!config) {
-        return;
-    }
+    console.log(config);
 
     if (config.hideHealthArmour) {
         alt.beginScaleformMovieMethodMinimap('SETUP_HEALTH_ARMOUR');
@@ -33,14 +35,20 @@ function tick() {
     let finalRadarState = true;
 
     if (config.hideMinimapOnFoot) {
-        finalRadarState = alt.Player.local.vehicle ? false : true;
+        finalRadarState = alt.Player.local.vehicle ? true : false;
     }
 
     if (config.hideMinimapInPage && useWebview().isAnyPageOpen()) {
         finalRadarState = false;
     }
 
+    if (lastRadarState === finalRadarState) {
+        return;
+    }
+
+    lastRadarState = finalRadarState;
     native.displayRadar(finalRadarState);
 }
 
 alt.everyTick(tick);
+alt.onServer(Events.systems.serverConfig.set, (newConfig: ServerConfig) => (config = newConfig));

--- a/src/main/server/api/index.ts
+++ b/src/main/server/api/index.ts
@@ -16,11 +16,17 @@ export function useApi() {
     }
 
     function get<K extends keyof ServerPlugin>(apiName: K): ServerPlugin[K] {
+        if (!registeredApis[apiName]) {
+            alt.logWarning(`The API, ${apiName} is undefined. Use 'getAsync' for obtaining the API instead.`);
+            alt.logWarning(`Example: const result = await api.getAsync('${apiName}');`);
+            alt.logWarning(`This could also be a missing plugin, make sure the plugin for ${apiName} is installed`);
+        }
+
         return registeredApis[apiName] as ServerPlugin[K];
     }
 
     async function getAsync<K extends keyof ServerPlugin>(apiName: K, timeout = 30000): Promise<ServerPlugin[K]> {
-        await alt.Utils.waitFor( () => isReady(apiName), timeout);
+        await alt.Utils.waitFor(() => isReady(apiName), timeout);
         return get(apiName);
     }
 

--- a/src/main/server/index.ts
+++ b/src/main/server/index.ts
@@ -160,8 +160,25 @@ export function useRebar() {
 declare module 'alt-shared' {
     // extending interface by interface merging
     export interface ICustomGlobalMeta {
+        /**
+         * Used for getting plugin APIs
+         *
+         * Only available on server-side, server folder
+         *
+         * @type {ReturnType<typeof useRebar>}
+         * @memberof ICustomGlobalMeta
+         */
         Rebar: ReturnType<typeof useRebar>;
+
+        /**
+         * Only available on server-side, server folder
+         *
+         * @type {ReturnType<typeof useApi>}
+         * @memberof ICustomGlobalMeta
+         */
+        RebarAPI: ReturnType<typeof useApi>;
     }
 }
 
 alt.setMeta('Rebar', useRebar());
+alt.setMeta('RebarPluginAPI', useRebar().useApi());

--- a/src/main/server/index.ts
+++ b/src/main/server/index.ts
@@ -62,6 +62,7 @@ import { useServerTime } from './systems/serverTime.js';
 import { useServerWeather } from './systems/serverWeather.js';
 import { useProxyFetch } from './systems/proxyFetch.js';
 import { usePed } from './controllers/ped.js';
+import { useServerConfig } from './systems/serverConfig.js';
 
 export function useRebar() {
     return {
@@ -140,6 +141,7 @@ export function useRebar() {
         },
         usePlayer,
         useProxyFetch,
+        useServerConfig,
         useServerTime,
         useServerWeather,
         utility: {
@@ -157,7 +159,7 @@ export function useRebar() {
     };
 }
 
-declare module 'alt-shared' {
+declare module 'alt-server' {
     // extending interface by interface merging
     export interface ICustomGlobalMeta {
         /**

--- a/src/main/server/player/raycast.ts
+++ b/src/main/server/player/raycast.ts
@@ -15,8 +15,11 @@ export function useRaycast(player: alt.Player) {
      * @param {K} type
      * @return {Promise<ReturnTypes[K]>}
      */
-    async function getFocusedEntity<K extends keyof ReturnTypes>(type: K): Promise<ReturnTypes[K] | undefined> {
-        return await player.emitRpc(Events.systems.raycast.getFocusedEntity, type);
+    async function getFocusedEntity<K extends keyof ReturnTypes>(
+        type: K,
+        debug = false,
+    ): Promise<ReturnTypes[K] | undefined> {
+        return await player.emitRpc(Events.systems.raycast.getFocusedEntity, type, debug);
     }
 
     /**
@@ -24,14 +27,16 @@ export function useRaycast(player: alt.Player) {
      *
      * **Keep in mind that `scriptId` is not the same for every player**
      *
-     * @return {Promise<{ pos: alt.Vector3; scriptId: number; model: number }>}
+     * @return {Promise<{ pos: alt.Vector3; scriptId: number; model: number, entityPos: alt.Vector3 }>}
      */
-    async function getFocusedObject(): Promise<{ pos: alt.Vector3; scriptId: number; model: number } | undefined> {
-        return await player.emitRpc(Events.systems.raycast.getFocusedObject);
+    async function getFocusedObject(
+        debug = false,
+    ): Promise<{ pos: alt.Vector3; scriptId: number; model: number; entityPos: alt.Vector3 } | undefined> {
+        return await player.emitRpc(Events.systems.raycast.getFocusedObject, debug);
     }
 
-    async function getFocusedPosition(): Promise<alt.Vector3 | undefined> {
-        return await player.emitRpc(Events.systems.raycast.getFocusedPosition);
+    async function getFocusedPosition(debug = false): Promise<alt.Vector3 | undefined> {
+        return await player.emitRpc(Events.systems.raycast.getFocusedPosition, debug);
     }
 
     return {

--- a/src/main/server/systems/serverConfig.ts
+++ b/src/main/server/systems/serverConfig.ts
@@ -1,0 +1,30 @@
+import * as alt from 'alt-server';
+
+interface ServerConfig {
+    hideHealthArmour?: boolean;
+    hideMinimapOnFoot?: boolean;
+    hideMinimapInPage?: boolean;
+    hideVehicleName?: boolean;
+    hideVehicleClass?: boolean;
+    hideStreetName?: boolean;
+    hideAreaName?: boolean;
+}
+
+declare module 'alt-shared' {
+    // extending interface by interface merging
+    export interface ICustomGlobalMeta {
+        ServerConfig: ServerConfig;
+    }
+}
+
+export function useServerConfig() {
+    function set<K extends keyof ServerConfig>(key: K, value: ServerConfig[K]) {
+        const config = alt.getMeta('ServerConfig') ?? {};
+        config[key] = value;
+        alt.setMeta('ServerConfig', config);
+    }
+
+    return {
+        set,
+    };
+}

--- a/src/main/server/systems/serverConfig.ts
+++ b/src/main/server/systems/serverConfig.ts
@@ -1,30 +1,24 @@
 import * as alt from 'alt-server';
+import { Events } from '../../shared/events/index.js';
+import { ServerConfig } from '../../shared/types/serverConfig.js';
 
-interface ServerConfig {
-    hideHealthArmour?: boolean;
-    hideMinimapOnFoot?: boolean;
-    hideMinimapInPage?: boolean;
-    hideVehicleName?: boolean;
-    hideVehicleClass?: boolean;
-    hideStreetName?: boolean;
-    hideAreaName?: boolean;
-}
+const config: ServerConfig = {};
 
-declare module 'alt-shared' {
-    // extending interface by interface merging
-    export interface ICustomGlobalMeta {
-        ServerConfig: ServerConfig;
+function updatePlayers() {
+    for (let player of alt.Player.all) {
+        player.emit(Events.systems.serverConfig.set, config);
     }
 }
 
 export function useServerConfig() {
     function set<K extends keyof ServerConfig>(key: K, value: ServerConfig[K]) {
-        const config = alt.getMeta('ServerConfig') ?? {};
         config[key] = value;
-        alt.setMeta('ServerConfig', config);
+        updatePlayers();
     }
 
     return {
         set,
     };
 }
+
+alt.on('playerConnect', (player) => player.emit(Events.systems.serverConfig.set, config));

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -103,6 +103,9 @@ export const Events = {
             getFocusedPosition: 'systems:raycast:get:focused:position',
             getFocusedObject: 'systems:raycast:get:focused:object',
         },
+        serverConfig: {
+            set: 'systems:server:config:set',
+        },
     },
     view: {
         onServer: 'webview:on:server',

--- a/src/main/shared/types/serverConfig.ts
+++ b/src/main/shared/types/serverConfig.ts
@@ -1,0 +1,9 @@
+export interface ServerConfig {
+    hideHealthArmour?: boolean;
+    hideMinimapOnFoot?: boolean;
+    hideMinimapInPage?: boolean;
+    hideVehicleName?: boolean;
+    hideVehicleClass?: boolean;
+    hideStreetName?: boolean;
+    hideAreaName?: boolean;
+}


### PR DESCRIPTION
## Version 20

### Code Changes

-   Made `raycast.getFocusedObject()` return `entityPos`
-   Clearly warn users using `api.get` for obtaining an API, and recommend async instead
-   Added new `getMeta` API for getting plugin API as single import
-   Added `debug` option to `raycast` functions to draw lines when a raycast is invoked

### Docs Changes

-   Added `debug` to raycast docs
-   Removed `get` from Plugin API examples, to let users focus on `async` instead
