### PR TITLE
feat: toggle controls, code examples in docs

### DIFF
--- a/docs/api/server/player/player-use.md
+++ b/docs/api/server/player/player-use.md
@@ -442,6 +442,10 @@ import { Weathers } from '@Shared/data/weathers.js';
 const Rebar = useRebar();
 const rebarPlayer = Rebar.usePlayer(player);
 
+// Toggle Game Controls
+rebarPlayer.world.enableControls();
+rebarPlayer.world.disableControls();
+
 // Blur the screen over 5 seconds, and keep it blurred
 rebarPlayer.world.setScreenBlur(5000);
 rebarPlayer.world.clearScreenBlur(5000);

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Version 25
+
+### Code Changes
+
+-   Added `account` document to `usePlayer`
+-   Fixed small permission `hasOne` error
+-   Added various shared `Utility` functions to Rebar.utility to lower import counts
+-   Added toggle controls to `usePlayer().world` to control controls state
+-   Fixed small bug where hotkeys could be invoked when game controls are disabled
+
+### Docs Changes
+
+-   Added code examples page
+-   Added troubleshooting page
+-   Updated player world api for toggling controls
+
+---
+
 ## Version 24
 
 ### Code Changes

--- a/docs/code-examples.md
+++ b/docs/code-examples.md
@@ -1,0 +1,492 @@
+# Code Examples
+
+This is a giant page for code examples and a general purpose cookbook for writing just about anything.
+
+Always check the documentation for further information and to see the full extent of what this framework has to offer.
+
+!!!
+Some of these code examples require other plugins to work.
+
+Check out [Plebmasters Forge](<https://forge.plebmasters.de/hub?targetFrameworks=Rebar+(alt:V)&contentType=Script>) to see all available plugins.
+!!!
+
+## Server API
+
+We mostly work on the server-side for a majority of the functionality.
+
+Here's how to import Rebar in various ways.
+
+```ts
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+```
+
+```ts
+import * as alt from 'alt-server';
+
+const Rebar = alt.getMeta('Rebar');
+```
+
+## Rebar Events
+
+Rebar has a handful of events that can be used in tandem with alt:V events.
+
+These become more useful when a character select, or auth plugins are installed.
+
+```ts
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const RebarEvents = Rebar.events.useEvents();
+
+RebarEvents.on('character-bound', (player) => {
+    // do something when they've selected a character
+});
+```
+
+```ts
+RebarEvents.on('account-bound', (player) => {
+    // do something when they've logged into an account
+});
+```
+
+```ts
+RebarEvents.on('time-changed', (hour, minute, second) => {
+    // Do something when the time changes in-game
+});
+```
+
+## Notifying a Player
+
+Send a default GTA:V notification to the player.
+
+```ts
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const RebarEvents = Rebar.events.useEvents();
+
+RebarEvents.on('character-bound', (player) => {
+    const rPlayer = Rebar.usePlayer(player);
+    rPlayer.notify.showNotification('Welcome to the server!');
+});
+```
+
+## Screen Shards
+
+Shards are like the `Mission Failed` full screen effect that you see in normal GTA:V. You can show them like this.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const RebarEvents = Rebar.events.useEvents();
+
+RebarEvents.on('character-bound', (player) => {
+    const rPlayer = Rebar.usePlayer(player);
+    rPlayer.notify.showShard({
+        title: 'Welcome to the Server',
+        duration: 2000,
+    });
+});
+```
+
+## Screen Mission Text
+
+Mission text will show in the bottom center of the screen.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const RebarEvents = Rebar.events.useEvents();
+
+RebarEvents.on('character-bound', (player) => {
+    const rPlayer = Rebar.usePlayer(player);
+    rPlayer.notify.showMissionText('Visit our website at https://rebarv.com');
+});
+```
+
+## Keybinds
+
+Keybinds can be done on server-side to allow for server-side callbacks.
+
+Here's a simple keybind that when `K` is pressed it teleports the player to a position.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const Keybinder = Rebar.useKeybinder();
+
+const K_KEY = 75;
+
+Keybinder.on(K_KEY, (player) => {
+    player.pos = new alt.Vector3({
+        x: 912,
+        y: -199,
+        z: 73,
+    });
+});
+```
+
+## Interaction Points
+
+Interaction points are places where the player can press `E` to do something.
+
+They can be accented with markers, text labels, and blips.
+
+There are also local versions of `marker`, `text label`, and `blips` to only show it to a single player. Which has full control via server-side.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+import { MarkerType } from '@Shared/types/marker.js';
+
+const Rebar = useRebar();
+
+const posRef = new alt.Vector3({
+    x: 912.6202392578125,
+    y: -198.6721649169922,
+    z: 71.22137451171875,
+});
+
+const interaction = Rebar.controllers.useInteraction(
+    new alt.ColshapeCylinder(posRef.x, posRef.y, posRef.z, 3, 3),
+    'player',
+);
+
+interaction.onEnter((player) => {
+    const rPlayer = Rebar.usePlayer(player);
+    rPlayer.notify.showNotification('Entered the point!');
+});
+
+interaction.onLeave((player) => {
+    const rPlayer = Rebar.usePlayer(player);
+    rPlayer.notify.showNotification('Left the point!');
+});
+
+interaction.on((player) => {
+    const rPlayer = Rebar.usePlayer(player);
+    rPlayer.notify.showNotification('Pressed E on the Point!');
+});
+
+Rebar.controllers.useMarkerGlobal({
+    pos: posRef,
+    color: new alt.RGBA(0, 255, 0, 75),
+    scale: new alt.Vector3(3, 3, 1),
+    type: MarkerType.CYLINDER,
+});
+
+Rebar.controllers.useTextLabelGlobal({
+    pos: posRef.add(0, 0, 1),
+    text: 'Press E to do something!',
+});
+
+Rebar.controllers.useBlipGlobal({
+    color: 6,
+    pos: posRef,
+    shortRange: true,
+    sprite: 128,
+    text: 'Interaction Point',
+});
+```
+
+## Server Configuration
+
+You can modify server configuration by creating a plugin that tweaks the settings.
+
+Here's an example of what you can invoke to change settings in Rebar.
+
+```ts
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const ServerConfig = Rebar.useServerConfig();
+
+ServerConfig.set('disablePistolWhip', true);
+ServerConfig.set('disableVehicleEngineAutoStart', true);
+ServerConfig.set('disableVehicleEngineAutoStop', true);
+ServerConfig.set('disableVehicleSeatSwap', true);
+ServerConfig.set('hideAreaName', true);
+ServerConfig.set('hideHealthArmour', true);
+ServerConfig.set('hideMinimapInPage', true);
+ServerConfig.set('hideMinimapInVehicle', true);
+ServerConfig.set('hideMinimapOnFoot', true);
+ServerConfig.set('hideStreetName', true);
+ServerConfig.set('hideVehicleClass', true);
+ServerConfig.set('hideVehicleName', true);
+```
+
+## Saving Player Data
+
+With a character select plugin, and auth plugin installed it's really easy to write data to the database using the document system.
+
+This document system also exists for other entities like Vehicles,and Accounts.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+
+type MyCustomData = {
+    mydata: string;
+};
+
+async function onSomeEvent(player: alt.Player) {
+    const rPlayer = Rebar.usePlayer(player);
+    await rPlayer.character.setBulk<MyCustomData>({
+        mydata: 'hello world!',
+    });
+
+    // Returns `hello world`
+    const mydata = rPlayer.character.getField<MyCustomData>('mydata');
+}
+```
+
+## Character & Account Permissions
+
+There's a built in permission system to assign players as admins, specific jobs, etc.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+
+function someFunction(player: alt.Player) {
+    const rPlayer = Rebar.usePlayer(player);
+
+    rPlayer.character.permission.addPermission('mechanic');
+    rPlayer.account.addPermission('admin');
+}
+```
+
+## Registering Commands
+
+With a `chat plugin` you can register commands and invoke them in-game in the chat window.
+
+Additionally, you can protect your commands from being ran under `Account Permissions` or `Character Permissions`.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const Messenger = Rebar.messenger.useMessenger();
+
+Messenger.commands.register({
+    name: 'test',
+    desc: '- Runs a test command',
+    callback: async (player) => {},
+});
+
+Messenger.commands.register({
+    name: 'adminonlycommand',
+    desc: '- Only admins can run this',
+    options: { accountPermissions: ['admin'] },
+    callback: async (player) => {
+        const rPlayer = Rebar.usePlayer(player);
+        rPlayer.notify.showNotification('Hello Admin!');
+    },
+});
+
+Messenger.commands.register({
+    name: 'mechaniconlycommand',
+    desc: '- Only mechanics can run this',
+    options: { permissions: ['mechanic'] },
+    callback: async (player) => {
+        const rPlayer = Rebar.usePlayer(player);
+        rPlayer.notify.showNotification('Hello Mechanic!');
+    },
+});
+```
+
+## Assigning Custom Models
+
+You can easily assign a custom player model to override their default character appearance.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+
+function someFunction(player: alt.Player) {
+    const rPlayer = Rebar.usePlayer(player);
+    rPlayer.clothing.setSkin('a_c_husky');
+}
+```
+
+## Assigning Uniforms
+
+You can also assign and clear uniforms for the player to wear.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+
+function someFunction(player: alt.Player) {
+    const rPlayer = Rebar.usePlayer(player);
+    rPlayer.clothing.setUniform([
+        { dlc: alt.hash('some_dlc'), drawable: 0, id: 5, texture: 0 },
+        { dlc: alt.hash('some_dlc'), drawable: 1, id: 6, texture: 0 },
+        { dlc: alt.hash('some_dlc'), drawable: 7, id: 2, texture: 0 },
+    ]);
+
+    rPlayer.clothing.clearUniform();
+}
+```
+
+## Owned Vehicles
+
+Vehicles can be owned by an individual player, or a `permission`.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+
+function someFunction(player: alt.Player) {
+    const rPlayer = Rebar.usePlayer(player);
+    const _id = rPlayer.character.getField('_id');
+
+    let veh: alt.Vehicle;
+    try {
+        veh = new alt.Vehicle('infernus', player.pos, player.rot);
+    } catch (err) {
+        // invalid vehicle model
+        return;
+    }
+
+    // Automatically stored into the database
+    Rebar.vehicle.useVehicle(veh).create(_id);
+}
+```
+
+## Spawn Owned Vehicles
+
+Want to easily spawn vehicles owned by a player, well Rebar makes it super simple.
+
+It even handles synchronizing mods, extras, lock state, engine damage, and more.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+
+async function someFunction(player: alt.Player) {
+    const rPlayer = Rebar.usePlayer(player);
+    const vehicles = await rPlayer.character.getVehicles();
+
+    for (let vehData of vehicles) {
+        if (Rebar.get.useVehicleGetter().isSpawned(vehData._id)) {
+            continue;
+        }
+
+        const newVehicle = new alt.Vehicle(vehData.model, vehData.pos, vehData.rot);
+        const rVehicle = Rebar.vehicle.useVehicle(newVehicle);
+        rVehicle.bind(vehData);
+    }
+}
+```
+
+## Teleport to a Waypoint
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+const Messenger = Rebar.messenger.useMessenger();
+
+Messenger.commands.register({
+    name: '/tpwp',
+    desc: 'teleport to a given waypoint',
+    callback: async (player: alt.Player) => {
+        const pos = await Rebar.player.useWaypoint(player).get();
+        if (!pos) {
+            return;
+        }
+
+        player.pos = pos.add(0, 0, 1);
+    },
+});
+```
+
+## Control Pedestrians
+
+We have a built in pedestrian controller on server-side that lets you invoke natives to easily make pedestrians do various things.
+
+Here's one that makes a bunch of them dance together.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+
+function someFunction(player: alt.Player) {
+    const peds: ReturnType<typeof Rebar.controllers.usePed>[] = [];
+
+    for (let i = 0; i < 10; i++) {
+        const ped = Rebar.controllers.usePed(new alt.Ped('mp_m_freemode_01', player.pos, player.rot, 100));
+        ped.setOption('makeStupid', true);
+        peds.push(ped);
+
+        ped.invoke('taskPlayAnim', 'timetable@tracy@ig_5@idle_a', 'idle_a', 8.0, 8.0, -1, 1, 0, false, false, false);
+    }
+
+    for (let ped of peds) {
+        ped.invoke('taskPlayAnim', 'timetable@tracy@ig_5@idle_a', 'idle_a', 8.0, 8.0, -1, 1, 0, false, false, false);
+    }
+}
+```
+
+## Raycast for Objects
+
+Raycast for an Object from server-side.
+
+```ts
+import * as alt from 'alt-server';
+import { useRebar } from '@Server/index.js';
+
+const Rebar = useRebar();
+
+// This may not work for all ATM models, just an example
+const models = [
+    //
+    alt.hash('prop_atm_01'),
+    alt.hash('prop_atm_02'),
+    alt.hash('prop_atm_03'),
+    alt.hash('prop_fleeca_atm'),
+];
+
+messenger.commands.register({
+    name: '/atm',
+    desc: '',
+    callback: async (player: alt.Player) => {
+        const rPlayer = Rebar.usePlayer(player);
+        const result = await rPlayer.raycast.getFocusedObject(true);
+
+        if (!result) {
+            return;
+        }
+
+        if (!models.includes(result.model)) {
+            return;
+        }
+
+        rPlayer.notify.showNotification('Interacting with an ATM!');
+    },
+});
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,56 @@
+# Troubleshooting
+
+!!!
+This troubleshooting guide mostly pertains to people who have successfully installed this framework.
+
+If you are still having trouble installing, kindly visit the Discord's help section.
+!!!
+
+## Clear `node_modules`
+
+Simply delete the entire `node_modules` folder.
+
+**Windows**
+
+```
+rmdir node_modules
+```
+
+**Linux**
+
+```
+rm -rf node_modules
+```
+
+Run `pnpm install` after completing this step.
+
+## Upgrade Server Binaries
+
+Run `pnpm upgrade` to get the latest version of alt:V Server Binaries.
+
+If this does not work remove the following files manually, and then upgrade:
+
+-   altv-crash-handler.exe
+-   altv-server.exe
+-   libnode.dll
+-   cache
+-   modules
+-   .server-crashes-cache
+
+Run `pnpm upgrade` after this has completed.
+
+## Clone Rebar Again
+
+If you're following the general principal of not modifying core code, you can simply move your plugins to a new instance of Rebar.
+
+Download a new copy of Rebar, move your plugins to the plugins folder.
+
+Install everything again with `pnpm install`, `pnpm upgrade`, and then do `pnpm start`.
+
+## Still Not Working?
+
+You're at a point where you'll need to start disabling plugins, or moving them out 1-by-1 to see which is the most problematic plugin.
+
+Remove all of your plugins, and start adding them back in 1-by-1, and running the server each time.
+
+If your server stops working after you re-introduced a plugin, then you've found your troublemaker.

--- a/package.json
+++ b/package.json
@@ -1,73 +1,73 @@
 {
-  "author": "stuyk",
-  "type": "module",
-  "version": "24",
-  "scripts": {
-    "dev": "nodemon -x pnpm start",
-    "dev:linux": "nodemon -x pnpm start:linux",
-    "start": "node ./scripts/compile.js && altv-server",
-    "start:linux": "node ./scripts/compile.js && ./altv-server",
-    "build:docker": "node ./scripts/compile.js -- docker",
-    "binaries": "pnpm altv-pkg",
-    "rebar:upgrade": "node ./scripts/upgrade.js",
-    "webview:dev": "node ./scripts/buildPluginDependencies.js && node ./scripts/copyFiles.js && node ./scripts/webview.js && pnpm -C webview run dev",
-    "postinstall": "pnpm binaries && pnpm build:docker"
-  },
-  "devDependencies": {
-    "@altv/types-client": "^16.2.2",
-    "@altv/types-natives": "^16.2.0",
-    "@altv/types-server": "^16.2.1",
-    "@altv/types-shared": "^16.2.1",
-    "@altv/types-webview": "^16.2.1",
-    "@altv/types-worker": "^16.2.0",
-    "@types/node": "^20.14.2",
-    "altv-pkg": "^2.7.5",
-    "autoprefixer": "^10.4.19",
-    "fast-glob": "^3.3.2",
-    "fkill": "^9.0.0",
-    "nodemon": "^3.1.3",
-    "postcss": "^8.4.38",
-    "prettier": "^3.3.1",
-    "prettier-plugin-tailwindcss": "^0.5.14",
-    "retypeapp": "^3.5.0",
-    "shx": "^0.3.4",
-    "sucrase": "^3.35.0",
-    "tailwindcss": "^3.4.4"
-  },
-  "dependencies": {
-    "@vitejs/plugin-vue": "^5.0.5",
-    "dotenv": "^16.4.5",
-    "mongodb": "^6.7.0",
-    "sjcl": "^1.0.8",
-    "typescript": "^5.4.5",
-    "vite": "^5.2.13",
-    "vue": "^3.4.27",
-    "vue-tsc": "^2.0.21"
-  },
-  "prettier": {
-    "tabWidth": 4,
-    "singleQuote": true,
-    "semi": true,
-    "printWidth": 120,
-    "plugins": [
-      "prettier-plugin-tailwindcss"
-    ]
-  },
-  "nodemonConfig": {
-    "verbose": false,
-    "ext": "ts, vue",
-    "watch": [
-      "./src",
-      "./webview"
-    ],
-    "ignore": [
-      "webview/pages/*",
-      "webview/vite.config.*",
-      "*/package.json",
-      "*.mjs",
-      "ignore*.ts",
-      "autogen*.ts",
-      "webview/src/main.ts"
-    ]
-  }
+    "author": "stuyk",
+    "type": "module",
+    "version": "25",
+    "scripts": {
+        "dev": "nodemon -x pnpm start",
+        "dev:linux": "nodemon -x pnpm start:linux",
+        "start": "node ./scripts/compile.js && altv-server",
+        "start:linux": "node ./scripts/compile.js && ./altv-server",
+        "build:docker": "node ./scripts/compile.js -- docker",
+        "binaries": "pnpm altv-pkg",
+        "rebar:upgrade": "node ./scripts/upgrade.js",
+        "webview:dev": "node ./scripts/buildPluginDependencies.js && node ./scripts/copyFiles.js && node ./scripts/webview.js && pnpm -C webview run dev",
+        "postinstall": "pnpm binaries && pnpm build:docker"
+    },
+    "devDependencies": {
+        "@altv/types-client": "^16.2.2",
+        "@altv/types-natives": "^16.2.0",
+        "@altv/types-server": "^16.2.1",
+        "@altv/types-shared": "^16.2.1",
+        "@altv/types-webview": "^16.2.1",
+        "@altv/types-worker": "^16.2.0",
+        "@types/node": "^20.14.2",
+        "altv-pkg": "^2.7.5",
+        "autoprefixer": "^10.4.19",
+        "fast-glob": "^3.3.2",
+        "fkill": "^9.0.0",
+        "nodemon": "^3.1.3",
+        "postcss": "^8.4.38",
+        "prettier": "^3.3.1",
+        "prettier-plugin-tailwindcss": "^0.5.14",
+        "retypeapp": "^3.5.0",
+        "shx": "^0.3.4",
+        "sucrase": "^3.35.0",
+        "tailwindcss": "^3.4.4"
+    },
+    "dependencies": {
+        "@vitejs/plugin-vue": "^5.0.5",
+        "dotenv": "^16.4.5",
+        "mongodb": "^6.7.0",
+        "sjcl": "^1.0.8",
+        "typescript": "^5.4.5",
+        "vite": "^5.2.13",
+        "vue": "^3.4.27",
+        "vue-tsc": "^2.0.21"
+    },
+    "prettier": {
+        "tabWidth": 4,
+        "singleQuote": true,
+        "semi": true,
+        "printWidth": 120,
+        "plugins": [
+            "prettier-plugin-tailwindcss"
+        ]
+    },
+    "nodemonConfig": {
+        "verbose": false,
+        "ext": "ts, vue",
+        "watch": [
+            "./src",
+            "./webview"
+        ],
+        "ignore": [
+            "webview/pages/*",
+            "webview/vite.config.*",
+            "*/package.json",
+            "*.mjs",
+            "ignore*.ts",
+            "autogen*.ts",
+            "webview/src/main.ts"
+        ]
+    }
 }

--- a/src/main/client/player/controls.ts
+++ b/src/main/client/player/controls.ts
@@ -1,0 +1,8 @@
+import * as alt from 'alt-client';
+import { Events } from '../../shared/events/index.js';
+
+function setControls(state: boolean) {
+    alt.toggleGameControls(state);
+}
+
+alt.onServer(Events.player.controls.set, setControls);

--- a/src/main/client/startup.ts
+++ b/src/main/client/startup.ts
@@ -3,6 +3,7 @@ import '../translate/index.js';
 
 // Load all other files after translate
 import './controllers/index.js';
+import './player/controls.js';
 import './rmlui/index.js';
 import './screen/index.js';
 import './system/index.js';

--- a/src/main/client/system/serverKeybind.ts
+++ b/src/main/client/system/serverKeybind.ts
@@ -17,6 +17,10 @@ function handleUpdate(keys: string[]) {
 }
 
 function handleKeyup(key: number) {
+    if (!alt.gameControlsEnabled()) {
+        return;
+    }
+
     if (!validKeys.has(key)) {
         return;
     }

--- a/src/main/server/document/account.ts
+++ b/src/main/server/document/account.ts
@@ -157,7 +157,7 @@ export function useAccount(player: alt.Player) {
      * @param {string} permission
      * @return {*}
      */
-    async function addPermission(player: alt.Player, permission: string) {
+    async function addPermission(permission: string) {
         if (!player.valid) {
             return false;
         }

--- a/src/main/server/player/index.ts
+++ b/src/main/server/player/index.ts
@@ -15,12 +15,14 @@ import { useCharacter } from '../document/character.js';
 import { usePlayerGetter } from '../getters/player.js';
 import { useVehicleGetter } from '../getters/vehicle.js';
 import { useRaycast } from './raycast.js';
+import { useAccount } from '../document/account.js';
 
 const playerGetter = usePlayerGetter();
 const vehicleGetter = useVehicleGetter();
 
 export function usePlayer(player: alt.Player) {
     return {
+        account: useAccount(player),
         animation: useAnimation(player),
         appearance: usePlayerAppearance(player),
         audio: useAudio(player),

--- a/src/main/server/player/world.ts
+++ b/src/main/server/player/world.ts
@@ -3,6 +3,7 @@ import { useNative } from './native.js';
 import { TimecycleTypes } from '@Shared/data/timecycleTypes.js';
 import { ScreenEffects } from '@Shared/data/screenEffects.js';
 import { Weathers } from '@Shared/data/weathers.js';
+import { Events } from '../../shared/events/index.js';
 
 export function useWorld(player: alt.Player) {
     const native = useNative(player);
@@ -109,12 +110,30 @@ export function useWorld(player: alt.Player) {
         native.invoke('pauseClock', true);
     }
 
+    function enableControls() {
+        if (!player || !player.valid) {
+            return;
+        }
+
+        player.emit(Events.player.controls.set, true);
+    }
+
+    function disableControls() {
+        if (!player || !player.valid) {
+            return;
+        }
+
+        player.emit(Events.player.controls.set, false);
+    }
+
     return {
         clearAllScreenEffects,
         clearScreenBlur,
         clearScreenEffect,
         clearScreenFade,
         clearTimecycle,
+        disableControls,
+        enableControls,
         setScreenBlur,
         setScreenEffect,
         setScreenFade,

--- a/src/main/server/systems/permission.ts
+++ b/src/main/server/systems/permission.ts
@@ -26,7 +26,7 @@ const InternalFunctions = {
     async add<CustomPerms = ''>(
         player: alt.Player,
         perm: DefaultPerms | CustomPerms,
-        dataName: SupportedDocuments
+        dataName: SupportedDocuments,
     ): Promise<boolean> {
         if (typeof documentType[dataName] === 'undefined') {
             alt.logWarning(`Athena.document.${dataName} is not a supported document type.`);
@@ -63,7 +63,7 @@ const InternalFunctions = {
     async remove<CustomPerms = ''>(
         player: alt.Player,
         perm: DefaultPerms | CustomPerms,
-        dataName: SupportedDocuments
+        dataName: SupportedDocuments,
     ): Promise<boolean> {
         if (typeof documentType[dataName] === 'undefined') {
             alt.logWarning(`Athena.document.${dataName} is not a supported document type.`);
@@ -149,10 +149,14 @@ const InternalFunctions = {
     hasOne<CustomPerms = ''>(
         player: alt.Player,
         perms: Array<DefaultPerms | CustomPerms>,
-        dataName: SupportedDocuments
+        dataName: SupportedDocuments,
     ): boolean {
         if (typeof documentType[dataName] === 'undefined') {
             alt.logWarning(`Athena.document.${dataName} is not a supported document type.`);
+            return false;
+        }
+
+        if (perms.length <= 0) {
             return false;
         }
 
@@ -194,7 +198,7 @@ const InternalFunctions = {
     hasAll<CustomPerms = ''>(
         player: alt.Player,
         perms: Array<DefaultPerms | CustomPerms>,
-        dataName: SupportedDocuments
+        dataName: SupportedDocuments,
     ): boolean {
         if (typeof documentType[dataName] === 'undefined') {
             alt.logWarning(`Athena.document.${dataName} is not a supported document type.`);
@@ -243,7 +247,7 @@ export function usePermission(player: alt.Player) {
      */
     async function add<CustomPerms = ''>(
         type: 'character' | 'account',
-        perm: DefaultPerms | CustomPerms
+        perm: DefaultPerms | CustomPerms,
     ): Promise<boolean> {
         return await InternalFunctions.add(player, perm, type);
     }
@@ -260,7 +264,7 @@ export function usePermission(player: alt.Player) {
      */
     async function remove<CustomPerms = ''>(
         type: 'character' | 'account',
-        perm: DefaultPerms | CustomPerms
+        perm: DefaultPerms | CustomPerms,
     ): Promise<boolean> {
         return await InternalFunctions.remove(player, perm, type);
     }
@@ -300,7 +304,7 @@ export function usePermission(player: alt.Player) {
      */
     function hasOne<CustomPerms = ''>(
         type: 'character' | 'account',
-        perms: Array<DefaultPerms | CustomPerms>
+        perms: Array<DefaultPerms | CustomPerms>,
     ): boolean {
         return InternalFunctions.hasOne(player, perms, type);
     }
@@ -315,7 +319,7 @@ export function usePermission(player: alt.Player) {
      */
     function hasAll<CustomPerms = ''>(
         type: 'character' | 'account',
-        perms: Array<DefaultPerms | CustomPerms>
+        perms: Array<DefaultPerms | CustomPerms>,
     ): boolean {
         return InternalFunctions.hasAll(player, perms, type);
     }
@@ -340,7 +344,7 @@ export function usePermission(player: alt.Player) {
  */
 export async function getAll<CustomPerms = ''>(
     type: 'character' | 'account',
-    perm: DefaultPerms | CustomPerms
+    perm: DefaultPerms | CustomPerms,
 ): Promise<Array<Account> | Array<Character>> {
     const collectionName = type === 'character' ? CollectionNames.Characters : CollectionNames.Accounts;
     const results = await getMany<Character | Account>({ permissions: [String(perm)] }, collectionName);

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -65,6 +65,9 @@ export const Events = {
                 local: 'audio:player:sound:2d',
             },
         },
+        controls: {
+            set: 'player:controls:set',
+        },
         native: {
             invoke: 'player:native:invoke',
         },


### PR DESCRIPTION
## Version 25

### Code Changes

-   Added `account` document to `usePlayer`
-   Fixed small permission `hasOne` error
-   Added various shared `Utility` functions to Rebar.utility to lower import counts
-   Added toggle controls to `usePlayer().world` to control controls state
-   Fixed small bug where hotkeys could be invoked when game controls are disabled

### Docs Changes

-   Added code examples page
-   Added troubleshooting page
-   Updated player world api for toggling controls
