### PR TITLE
fix: Build plugin dependencies on upgrade to be able to build

### DIFF
--- a/scripts/upgrade.js
+++ b/scripts/upgrade.js
@@ -39,6 +39,7 @@ try {
         moveDirectory(from, to, file.includes('.') ? false : true);
     }
 
+    execSync(`node ./scripts/buildPluginDependencies.js`, { stdio: 'inherit' });
     execSync(`pnpm upgrade`, { stdio: 'inherit' });
     execSync(`pnpm install`, { stdio: 'inherit' });
     fs.rmSync(tmpPath, { force: true, recursive: true });


### PR DESCRIPTION
If you have a `dependencies.json` or `package.json` file in one of your plugins, you won't be able to run upgrade command, because it will run postinstall script that builds project. This PR should solve this issue.