### PR TITLE
feat: page open, page close, escape to close

### DIFF
--- a/docs/api/server/events/events.md
+++ b/docs/api/server/events/events.md
@@ -49,4 +49,16 @@ RebarEvents.on('time-minute-changed', (minute) => {
 RebarEvents.on('time-second-changed', (second) => {
     console.log(second);
 });
+
+// Called when a page is opened
+RebarEvents.on('page-opened', (player, pageName) => {
+    console.log('page opened');
+    console.log(pageName);
+});
+
+// Called when a page is closed
+RebarEvents.on('page-closed', (player, pageName) => {
+    console.log('page closed');
+    console.log(pageName);
+});
 ```

--- a/docs/api/server/player/player-use.md
+++ b/docs/api/server/player/player-use.md
@@ -407,6 +407,9 @@ async function someWebviewThing(player: alt.Player, attempts = 0) {
     // Show a specific page
     rebarPlayer.webview.show('Example', 'page');
 
+    // Show a specific page, but allow them to leave by pressing escape
+    rebarPlayer.webview.show('Example', 'page', true);
+
     if (attempts >= 5) {
         player.kick('something went wrong');
         return;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Version 27
+
+### Code Changes
+
+-   Added `onClose` function for webview
+-   Added `escapeToClosePage` to `show` function for webviews
+    -   Keep in mind this only works for `page` types
+-   Added `RebarEvent` for page open and page close on server-side
+
+## Docs Changes
+
+-   Updated `playerUse` webview section for `show` function to include info about escape to close
+-   Added `RebarEvent` onClose and onOpen docs
+
+---
+
 ## Version 26
 
 ### Code Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "author": "stuyk",
     "type": "module",
-    "version": "26",
+    "version": "27",
     "scripts": {
         "dev": "nodemon -x pnpm start",
         "dev:linux": "nodemon -x pnpm start:linux",
@@ -14,7 +14,7 @@
         "postinstall": "pnpm binaries && pnpm build:docker"
     },
     "devDependencies": {
-        "@altv/types-client": "^16.2.2",
+        "@altv/types-client": "^16.2.3",
         "@altv/types-natives": "^16.2.0",
         "@altv/types-server": "^16.2.1",
         "@altv/types-shared": "^16.2.1",
@@ -27,7 +27,7 @@
         "fkill": "^9.0.0",
         "nodemon": "^3.1.3",
         "postcss": "^8.4.38",
-        "prettier": "^3.3.1",
+        "prettier": "^3.3.2",
         "prettier-plugin-tailwindcss": "^0.5.14",
         "retypeapp": "^3.5.0",
         "shx": "^0.3.4",
@@ -40,7 +40,7 @@
         "mongodb": "^6.7.0",
         "sjcl": "^1.0.8",
         "typescript": "^5.4.5",
-        "vite": "^5.2.13",
+        "vite": "^5.3.0",
         "vue": "^3.4.27",
         "vue-tsc": "^2.0.21"
     },

--- a/src/main/server/events/index.ts
+++ b/src/main/server/events/index.ts
@@ -3,6 +3,8 @@ import { Account } from '@Shared/types/account.js';
 import { Character } from '@Shared/types/character.js';
 import { Vehicle } from '@Shared/types/vehicle.js';
 import { Weathers } from '@Shared/data/weathers.js';
+import { PageNames } from '../../shared/webview/index.js';
+import { Events } from '../../shared/events/index.js';
 
 type RebarEvents = {
     'weather-forecast-changed': (weather: Weathers[]) => void;
@@ -14,6 +16,8 @@ type RebarEvents = {
     'account-bound': (player: alt.Player, document: Account) => void;
     'character-bound': (player: alt.Player, document: Character) => void;
     'vehicle-bound': (vehicle: alt.Vehicle, document: Vehicle) => void;
+    'page-closed': (player: alt.Player, page: PageNames) => void;
+    'page-opened': (player: alt.Player, page: PageNames) => void;
     message: (player: alt.Player, message: string) => void;
 };
 
@@ -29,6 +33,8 @@ const eventCallbacks: EventCallbacks<keyof RebarEvents> = {
     'account-bound': [],
     'character-bound': [],
     'vehicle-bound': [],
+    'page-closed': [],
+    'page-opened': [],
     message: [],
 };
 
@@ -50,3 +56,13 @@ export function useEvents() {
         on,
     };
 }
+
+// Listens for when a page is opened
+alt.onClient(Events.view.onPageOpen, (player: alt.Player, pageName: PageNames) =>
+    useEvents().invoke('page-opened', player, pageName),
+);
+
+// Listens for when a page is closed
+alt.onClient(Events.view.onPageClose, (player: alt.Player, pageName: PageNames) =>
+    useEvents().invoke('page-closed', player, pageName),
+);

--- a/src/main/server/player/webview.ts
+++ b/src/main/server/player/webview.ts
@@ -10,6 +10,13 @@ const SessionKeys = {
 };
 
 export function useWebview(player: alt.Player) {
+    /**
+     * Emit an event directly to the webview
+     *
+     * @param {string} eventName
+     * @param {...any[]} args
+     * @return
+     */
     function emit(eventName: string, ...args: any[]) {
         if (!player || !player.valid) {
             return;
@@ -18,14 +25,32 @@ export function useWebview(player: alt.Player) {
         player.emit(Events.view.onServer, eventName, ...args);
     }
 
-    function show(vuePage: PageNames, type: PageType) {
+    /**
+     * Show a specific webview page to the player.
+     *
+     * Assign the `type` of page to change how it behaves.
+     *
+     * Escape to close page, only effects page types.
+     *
+     * @param {PageNames} vuePage
+     * @param {PageType} type
+     * @param {boolean} [escapeToClosePage=false]
+     * @return
+     */
+    function show(vuePage: PageNames, type: PageType, escapeToClosePage = false) {
         if (!player || !player.valid) {
             return;
         }
 
-        player.emit(Events.view.show, vuePage, type);
+        player.emit(Events.view.show, vuePage, type, escapeToClosePage);
     }
 
+    /**
+     * Hide a page that was shown to the player
+     *
+     * @param {PageNames} vuePage
+     * @return
+     */
     function hide(vuePage: PageNames) {
         if (!player || !player.valid) {
             return;
@@ -34,6 +59,11 @@ export function useWebview(player: alt.Player) {
         player.emit(Events.view.hide, vuePage, 'page');
     }
 
+    /**
+     * Focus the webview, and show the cursor
+     *
+     * @return
+     */
     function focus() {
         if (!player || !player.valid) {
             return;
@@ -42,6 +72,11 @@ export function useWebview(player: alt.Player) {
         player.emit(Events.view.focus);
     }
 
+    /**
+     * Unfocus the webview, and hide the cursor
+     *
+     * @return
+     */
     function unfocus() {
         if (!player || !player.valid) {
             return;
@@ -50,6 +85,13 @@ export function useWebview(player: alt.Player) {
         player.emit(Events.view.unfocus);
     }
 
+    /**
+     * Verify if a page is currently ready
+     *
+     * @param {PageNames} pageName
+     * @param {PageType} type
+     * @return
+     */
     async function isReady(pageName: PageNames, type: PageType) {
         if (type === 'page') {
             try {

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -151,5 +151,7 @@ export const Events = {
         localStorageSet: 'webview:localstorage:set',
         localStorageGet: 'webview:localstorage:get',
         localStorageDelete: 'webview:localstorage:delete',
+        onPageClose: 'webview:page:close',
+        onPageOpen: 'webview:page:open',
     },
 };


### PR DESCRIPTION
## Version 27

### Code Changes

-   Added `onClose` function for webview
-   Added `escapeToClosePage` to `show` function for webviews
    -   Keep in mind this only works for `page` types
-   Added `RebarEvent` for page open and page close on server-side

## Docs Changes

-   Updated `playerUse` webview section for `show` function to include info about escape to close
-   Added `RebarEvent` onClose and onOpen docs