### PR TITLE
feat: disable cam, actions, etc. closes #58

### DIFF
--- a/docs/api/server/player/player-use.md
+++ b/docs/api/server/player/player-use.md
@@ -449,6 +449,16 @@ const rebarPlayer = Rebar.usePlayer(player);
 rebarPlayer.world.enableControls();
 rebarPlayer.world.disableControls();
 
+// Disable Camera Controls (still allows walking)
+rebarPlayer.world.disableCameraControls(true);
+
+// Disable Attacking (still allows walking)
+rebarPlayer.world.disableAttackControls(true);
+
+// Freeze gameplay camera, will freeze the gameplay camera in its last known place
+// It's almost like dropping a camera on the ground
+rebarPlayer.world.freezeCamera(true);
+
 // Blur the screen over 5 seconds, and keep it blurred
 rebarPlayer.world.setScreenBlur(5000);
 rebarPlayer.world.clearScreenBlur(5000);

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Version 31
+
+### Code Changes
+
+-   Added `disableAttackControls`, `disableCameraControls`, and `freezeCamera` to player.world pathway
+-   Fixed issue with local progress bars not clearing
+-   Fixed issue with `gif` files not being copied correctly
+
+### Docs Changes
+
+-   Added documentation covering `player.world` new functions
+
+---
+
 ## Version 30
 
 ### Code Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "author": "stuyk",
     "type": "module",
-    "version": "30",
+    "version": "31",
     "scripts": {
         "dev": "nodemon -x pnpm start",
         "dev:linux": "nodemon -x pnpm start:linux",

--- a/src/main/client/player/controls.ts
+++ b/src/main/client/player/controls.ts
@@ -1,8 +1,62 @@
 import * as alt from 'alt-client';
+import * as native from 'natives';
 import { Events } from '../../shared/events/index.js';
+
+let disableCameraControls = false;
+let disableAttackControls = false;
+let interval: number;
+
+function tick() {
+    if (!disableCameraControls) {
+        return;
+    }
+
+    if (disableCameraControls) {
+        // Camera Movement
+        native.disableControlAction(0, 1, true);
+        native.disableControlAction(0, 2, true);
+        native.disableControlAction(0, 3, true);
+        native.disableControlAction(0, 4, true);
+        native.disableControlAction(0, 5, true);
+        native.disableControlAction(0, 6, true);
+    }
+
+    if (disableAttackControls) {
+        // Scroll Wheel
+        native.disableControlAction(0, 14, true);
+        native.disableControlAction(0, 15, true);
+        native.disableControlAction(0, 16, true);
+        native.disableControlAction(0, 17, true);
+
+        // Attacking
+        native.disableControlAction(0, 24, true);
+        native.disableControlAction(0, 25, true);
+    }
+}
 
 function setControls(state: boolean) {
     alt.toggleGameControls(state);
 }
 
+function setCameraFrozen(state: boolean) {
+    alt.setCamFrozen(state);
+}
+
+function setCameraControlsDisabled(state: boolean) {
+    disableCameraControls = state;
+
+    if (!interval) {
+        alt.setInterval(tick, 0);
+    }
+}
+
+function setAttackControlsDisabled(state: boolean) {}
+
 alt.onServer(Events.player.controls.set, setControls);
+alt.onServer(Events.player.controls.setCameraFrozen, setCameraFrozen);
+alt.onServer(Events.player.controls.setCameraControlsDisabled, setCameraControlsDisabled);
+alt.onServer(Events.player.controls.setAttackControlsDisabled, setAttackControlsDisabled);
+
+alt.on('connectionComplete', () => {
+    alt.setCamFrozen(false);
+});

--- a/src/main/server/player/world.ts
+++ b/src/main/server/player/world.ts
@@ -126,14 +126,61 @@ export function useWorld(player: alt.Player) {
         player.emit(Events.player.controls.set, false);
     }
 
+    /**
+     * Set to true to freeze the camera in its current place.
+     * It's effectively like dropping a camera on the ground.
+     *
+     * @param {boolean} value
+     * @return
+     */
+    function freezeCamera(value: boolean) {
+        if (!player || !player.valid) {
+            return;
+        }
+
+        player.emit(Events.player.controls.setCameraFrozen, value);
+    }
+
+    /**
+     * Disable camera controls entirely, prevents looking around
+     *
+     * @param {boolean} value
+     * @return
+     */
+    function disableCameraControls(value: boolean) {
+        if (!player || !player.valid) {
+            return;
+        }
+
+        player.emit(Events.player.controls.setCameraControlsDisabled, value);
+    }
+
+    /**
+     * Disable attacking via shooting, punching, etc.
+     * Also disabled weapon swapping.
+     *
+     * @param {boolean} value
+     * @return
+     */
+    function disableAttackControls(value: boolean) {
+        if (!player || !player.valid) {
+            return;
+        }
+
+        player.emit(Events.player.controls.setAttackControlsDisabled, value);
+    }
+
     return {
         clearAllScreenEffects,
         clearScreenBlur,
         clearScreenEffect,
         clearScreenFade,
         clearTimecycle,
+        disableAttackControls,
+        disableCameraControls,
         disableControls,
         enableControls,
+        freezeCamera,
         setScreenBlur,
         setScreenEffect,
         setScreenFade,

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -54,6 +54,9 @@ export const Events = {
         },
         controls: {
             set: 'player:controls:set',
+            setCameraFrozen: 'player:controls:setFrozen',
+            setAttackControlsDisabled: 'player:controls:set:attack:disabled',
+            setCameraControlsDisabled: 'player:controls:set:disabled',
         },
         native: {
             invoke: 'player:native:invoke',


### PR DESCRIPTION
## Version 31

### Code Changes

-   Added `disableAttackControls`, `disableCameraControls`, and `freezeCamera` to player.world pathway
-   Fixed issue with local progress bars not clearing
-   Fixed issue with `gif` files not being copied correctly

### Docs Changes

-   Added documentation covering `player.world` new functions