### PR TITLE
Fix overwriting of vehicle handling data

### DIFF
--- a/src/main/client/system/vehicleHandling.ts
+++ b/src/main/client/system/vehicleHandling.ts
@@ -8,14 +8,20 @@ alt.on('streamSyncedMetaChange', (vehicle: alt.BaseObject, key: string) => {
     if (!(vehicle instanceof alt.Vehicle)) {
         return;
     }
+    const handlingData: Partial<alt.HandlingData> = vehicle.getStreamSyncedMeta('handling');
 
-    vehicle.handling = Object.assign(vehicle.handling, vehicle.getStreamSyncedMeta('handling'));
+    for (const [key, value] of Object.entries(handlingData)) {
+        vehicle.handling[key] = value;
+    }
 });
 
 alt.on('enteredVehicle', (vehicle, seat) => {
     if (!vehicle.hasStreamSyncedMeta('handling')) {
         return;
     }
+    const handlingData: Partial<alt.HandlingData> = vehicle.getStreamSyncedMeta('handling');
 
-    vehicle.handling = Object.assign(vehicle.handling, vehicle.getStreamSyncedMeta('handling'));
+    for (const [key, value] of Object.entries(handlingData)) {
+        vehicle.handling[key] = value;
+    }
 });


### PR DESCRIPTION
Correction of the overwriting of the vehicle handling data. 

Problem:
The variable `vehicle.handling` cannot be overwritten with `Object.assign`.