### PR TITLE
feat: Instructional buttons server-side

### DIFF
--- a/src/main/client/index.ts
+++ b/src/main/client/index.ts
@@ -10,6 +10,7 @@ import { useNativeMenu } from './menus/native/index.js';
 import { useClonedPed } from './ped/clone.js';
 
 import { useCamera } from './player/camera.js';
+import { useControls } from './player/controls.js';
 
 import * as math from './utility/math/index.js';
 import * as text from './utility/text/index.js';
@@ -52,6 +53,7 @@ export function useRebarClient() {
         player: {
             useCamera,
             useRaycast,
+            useControls,
         },
         screen: {
             text: {

--- a/src/main/client/screen/instructionalButtons.ts
+++ b/src/main/client/screen/instructionalButtons.ts
@@ -1,8 +1,10 @@
+import { Events } from '@Shared/events/index.js';
+import { InstructionalButtons } from '@Shared/types/instructionalButtons.js';
 import * as alt from 'alt-client';
 import * as native from 'natives';
 
 let interval: number;
-let buttons: { text: string; input: string }[] = [];
+let buttons: InstructionalButtons = [];
 let scaleform: number;
 
 native.displayOnscreenKeyboard(0, 'FMMC_KEY_TIP8', '', '', '', '', '', 128);
@@ -21,7 +23,7 @@ function draw() {
 }
 
 export function useInstructionalButtons() {
-    async function create(_buttons: { text: string; input: string }[]) {
+    async function create(_buttons: InstructionalButtons) {
         if (scaleform) {
             destroy();
         }
@@ -73,8 +75,17 @@ export function useInstructionalButtons() {
         buttons = [];
     }
 
+    async function get() {
+        return buttons;
+    }
+
     return {
+        get,
         create,
         destroy,
     };
 }
+
+alt.onServer(Events.player.screen.instructionalButtons.create, useInstructionalButtons().create);
+alt.onServer(Events.player.screen.instructionalButtons.destroy, useInstructionalButtons().destroy);
+alt.onRpc(Events.player.screen.instructionalButtons.get, useInstructionalButtons().get);

--- a/src/main/server/controllers/instructionalButtons.ts
+++ b/src/main/server/controllers/instructionalButtons.ts
@@ -1,0 +1,35 @@
+import * as alt from 'alt-server';
+
+import { Events } from '@Shared/events/index.js';
+import { InstructionalButtons } from '@Shared/types/instructionalButtons.js';
+
+
+/**
+ * Use Instructional Buttons for a player.
+ * @param player The player to use Instructional Buttons for.
+ */
+export function useInstructionalButtons(player: alt.Player) {
+    /**
+     * Create Instructional Buttons for a player.
+     * @param  buttons An array of buttons to create.
+     * @return {Promise<boolean>} True if successful. False if buttons already exist.
+     */
+    async function create(buttons: InstructionalButtons): Promise<boolean> {
+        const currentButtons = await player.emitRpc(Events.player.screen.instructionalButtons.get);
+        if (currentButtons) {
+            alt.logError(`Instructional Buttons already exist for this player. Prefer to destroy before creating.`);
+            return false;
+        };
+        player.emit(Events.player.screen.instructionalButtons.create, buttons);
+        return true;
+    }
+
+    /**
+     * Destroy Instructional Buttons for a player.
+     */
+    function destroy(): void {
+        player.emit(Events.player.screen.instructionalButtons.destroy);
+    }
+
+    return { create, destroy };
+}

--- a/src/main/server/controllers/interaction.ts
+++ b/src/main/server/controllers/interaction.ts
@@ -67,11 +67,13 @@ function onEnter(colshape: alt.Colshape, entity: alt.Entity) {
 function onLeave(colshape: alt.Colshape, entity: alt.Entity) {
     const index = getIndex(colshape);
     if (index <= -1) {
+        if (entity instanceof alt.Player) entity.emit(Events.controllers.interaction.clear);
         return;
     }
 
     const interaction = interactions[index];
     if (!isValid(entity, interaction)) {
+        if (entity instanceof alt.Player) entity.emit(Events.controllers.interaction.clear);
         return;
     }
 

--- a/src/main/server/index.ts
+++ b/src/main/server/index.ts
@@ -80,6 +80,7 @@ import { useStreamSyncedBinder } from './systems/streamSyncedBinder.js';
 import { useRaycast } from './player/raycast.js';
 import { useAttachment } from './player/attachment.js';
 import { useInteractionLocal } from './controllers/interactionLocal.js';
+import { useInstructionalButtons } from './controllers/instructionalButtons.js';
 
 export function useRebar() {
     return {
@@ -90,6 +91,7 @@ export function useRebar() {
             useBlipLocal,
             useD2DTextLabel,
             useD2DTextLabelLocal,
+            useInstructionalButtons,
             useInteraction,
             useInteractionLocal,
             useMarkerGlobal,

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -95,6 +95,11 @@ export const Events = {
             ped: {
                 show: 'player:show:ped:on:screen',
             },
+            instructionalButtons: {
+                create: 'player:screen:instructionalButtons:create',
+                destroy: 'player:screen:instructionalButtons:destroy',
+                get: 'player:screen:instructionalButtons:get',
+            },
         },
         webview: {
             set: {

--- a/src/main/shared/types/index.ts
+++ b/src/main/shared/types/index.ts
@@ -4,6 +4,7 @@ export * from './blip.js';
 export * from './character.js';
 export * from './clothingComponent.js';
 export * from './credits.js';
+export * from './instructionalButtons.js';
 export * from './marker.js';
 export * from './nativeMenu.js';
 export * from './object.js';

--- a/src/main/shared/types/instructionalButtons.ts
+++ b/src/main/shared/types/instructionalButtons.ts
@@ -1,0 +1,1 @@
+export type InstructionalButtons = { text: string; input: string }[];


### PR DESCRIPTION
1. feat: Added a functionality to create/destroy instructional buttons from server.
2. enhancement: Exposed `useControls` in `useRebarClient`.
3. fix: A small bug for interaction's `onLeave` event - it now triggers a client event only if the entity is player.