### PR TITLE
fix: Push a correct synced stream meta to webview

### DIFF
--- a/src/main/client/webview/index.ts
+++ b/src/main/client/webview/index.ts
@@ -325,7 +325,7 @@ export function useWebview(path = 'http://assets/webview/index.html') {
     }
 
     function onSyncedMetaChange(object: alt.Object, key: string, newValue: any) {
-        if (native.isEntityAPed(object.scriptID)) {
+        if (native.isEntityAPed(object.scriptID) && object.scriptID === alt.Player.local.scriptID) {
             webview.emit(Events.view.syncPartialCharacter, key, newValue);
             return;
         }


### PR DESCRIPTION
How to reproduce this bug before this fix got applied:
1. Connect to server from two computers.
2. Place two characters in the stream (near each other).
3. `useCharacter(player1).setField('dummy', 1)`
4. Webview of `player2` can see the `dummy=1`, but in database only `player1` has `dummy=1` as it was set.

If players are not in stream, the values were changed and then they are entering the same zone - it's starting to behave erratically.