### PR TITLE
Add new Function "getFocusedCustom" to Player.raycast

### DIFF
--- a/src/main/client/system/raycasts.ts
+++ b/src/main/client/system/raycasts.ts
@@ -79,6 +79,8 @@ export function useRaycast() {
         return undefined;
     }
 
+
+
     /**
      * Get the object the player is looking at
      *
@@ -118,10 +120,27 @@ export function useRaycast() {
         return results.coords;
     }
 
+    function getFocusedCustom(flag: number, debug = false) {
+        const results = performRaycast(flag, debug);
+        if (!results.result || !results.didHit) {
+            return undefined;
+        }
+        const type = native.getEntityType(results.entity);
+        const entityPos = native.getEntityCoords(results.entity, false);
+
+        return {
+            scriptId: results.entity,
+            type,
+            pos: results.coords,
+            entityPos,
+        };
+    }
+
     return {
         getFocusedEntity,
         getFocusedObject,
         getFocusedPosition,
+        getFocusedCustom,
     };
 }
 
@@ -130,3 +149,4 @@ const raycast = useRaycast();
 alt.onRpc(Events.systems.raycast.getFocusedEntity, raycast.getFocusedEntity);
 alt.onRpc(Events.systems.raycast.getFocusedObject, raycast.getFocusedObject);
 alt.onRpc(Events.systems.raycast.getFocusedPosition, raycast.getFocusedPosition);
+alt.onRpc(Events.systems.raycast.getFocusedCustom, raycast.getFocusedCustom);

--- a/src/main/server/player/raycast.ts
+++ b/src/main/server/player/raycast.ts
@@ -39,9 +39,29 @@ export function useRaycast(player: alt.Player) {
         return await player.emitRpc(Events.systems.raycast.getFocusedPosition, debug);
     }
 
+    async function getFocusedCustom(flag: number, debug = false) {
+        const validValues = [0, 1, 2, 4, 8, 16, 32, 128, 256, 4294967295];
+
+        if (flag !== -1) {
+            let flagcalc = flag;
+            for (const value of validValues) {
+                if ((flagcalc & value) === value) {
+                    flagcalc -= value;
+                }
+            }
+
+            if (flagcalc !== 0) {
+                return undefined;
+            }
+        }
+
+        return await player.emitRpc(Events.systems.raycast.getFocusedCustom, flag, debug);
+    }
+
     return {
         getFocusedEntity,
         getFocusedObject,
         getFocusedPosition,
+        getFocusedCustom,
     };
 }

--- a/src/main/shared/events/index.ts
+++ b/src/main/shared/events/index.ts
@@ -138,6 +138,7 @@ export const Events = {
             getFocusedEntity: 'systems:raycast:get:focused:entity',
             getFocusedPosition: 'systems:raycast:get:focused:position',
             getFocusedObject: 'systems:raycast:get:focused:object',
+            getFocusedCustom: 'systems:raycast:get:focused:custom',
         },
         screenshot: {
             get: 'systems:screenshot:get',


### PR DESCRIPTION
A new function has been added which allows the following flags (server side checks for valid BitAnd) to be specified as parameters.

None = 0,
IntersectWorld = 1,
IntersectVehicles = 2,
IntersectPedsSimpleCollision = 4,
IntersectPeds = 8,
IntersectObjects = 16,
IntersectWater = 32,
Unknown = 128,
IntersectFoliage = 256,
IntersectEverything = 4294967295