### PR TITLE
Adding method send to client-side messenger

### DIFF
--- a/src/main/client/system/messenger.ts
+++ b/src/main/client/system/messenger.ts
@@ -1,3 +1,6 @@
+import * as alt from 'alt-client';
+import { Events } from '@Shared/events/index.js';
+
 let chatIsFocused = false;
 
 export function useMessenger() {
@@ -13,9 +16,14 @@ export function useMessenger() {
         return chatIsFocused;
     }
 
+    function send(message: string) {
+        alt.emitServer(Events.systems.messenger.process, message);
+    }
+
     return {
         focusChat,
         isChatFocused,
         unfocusChat,
+        send
     };
 }


### PR DESCRIPTION
Just an additional method I use in one of the sever plugins, it allows one to run chat commands programatically using client code, like this example:

![image](https://github.com/user-attachments/assets/e0ead182-ea27-4d25-88b4-d413aa20b3c7)

Here a menu interaction will send a chat command once the player selects the given menu option

Obviously not so useful, as you can achieve the same using events, but for lazy guys like me, may be useful. 

It goes as a suggestion, since I understand it may not be worth the merge.