### PR TITLE
@Plugin path resolver

### DIFF
--- a/scripts/pathResolver.js
+++ b/scripts/pathResolver.js
@@ -10,6 +10,7 @@ function updatePaths(path) {
     file = file.replace(/\@Server/gm, `${relativePath}main/server`);
     file = file.replace(/\@Client/gm, `${relativePath}main/client`);
     file = file.replace(/\@Shared/gm, `${relativePath}main/shared`);
+    file = file.replace(/\@Plugins/gm, `${relativePath}plugins`);
     fs.writeFileSync(path, file);
 }
 


### PR DESCRIPTION
This resolves the issue from '@Plugin/...'.
It is annoying because IDE always auto-imports from there, but the compiler cannot resolve it, leading to errors in runtime (not compile time). 