### PR TITLE
feat: clearing ped props before setting new ones

### DIFF
--- a/src/main/client/ped/clone.ts
+++ b/src/main/client/ped/clone.ts
@@ -125,6 +125,9 @@ export function useClonedPed() {
 
         native.setHeadBlendEyeColor(ped, appearance.eyes);
 
+        // Clearing all props
+        native.clearAllPedProps(ped, 0);
+
         // Default Clothes for Even Customization
         for (let component of clothing) {
             if (component.isProp) {


### PR DESCRIPTION
This fixes a bug when you call this method multiple times.
1. When you call it with an array that has a prop (lets say a hat)
2. Then you call it again with the same array but without that prop.
Hat will stay despite it is being removed from an array. This fixes it.